### PR TITLE
Local state and multi instance with WT_BASE_SETTINGS_PATH env

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -18,7 +18,7 @@
 
   <Identity Name="WindowsTerminalDev"
     Publisher="CN=Dm17tryK"
-    Version="1.24.53103.3" />
+    Version="1.24.53104.3" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreNameDev</DisplayName>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -18,7 +18,7 @@
 
   <Identity Name="WindowsTerminalDev"
     Publisher="CN=Dm17tryK"
-    Version="1.24.53104.3" />
+    Version="1.24.53104.4" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreNameDev</DisplayName>

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -312,7 +312,6 @@
       <DependentUpon>MarkdownPaneContent.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
-
   </ItemGroup>
   <!-- ========================= idl Files ======================== -->
   <ItemGroup>
@@ -443,7 +442,6 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
   </ItemGroup>
   <PropertyGroup>
     <!-- This is a hack to get the ARM64 CI build working. See
@@ -508,6 +506,14 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
       <!-- Manually disable unreachable code warning, because jconcpp has a ton of that. -->
       <DisableSpecificWarnings>4702;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</TreatWarningAsError>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</TreatWarningAsError>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies>WindowsApp.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
@@ -43,8 +43,6 @@
     </ClCompile>
     <ClCompile Include="Toast.cpp" />
     <ClCompile Include="LanguageProfileNotifier.cpp" />
-    <ClCompile Include="Monarch.cpp" />
-    <ClCompile Include="Peasant.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -80,8 +78,6 @@
     <ClInclude Include="Toast.h" />
     <ClInclude Include="LanguageProfileNotifier.h" />
     <ClInclude Include="WindowsPackageManagerFactory.h" />
-    <ClInclude Include="Monarch.h" />
-    <ClInclude Include="Peasant.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="AppLogic.idl">
@@ -111,7 +107,7 @@
     <Midl Include="TaskbarState.idl" />
     <Midl Include="IPaneContent.idl" />
     <Midl Include="TerminalSettingsCache.idl" />
-    <Midl Include="Monarch.idl" />
+    <Midl Include="Remoting.idl" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="MinMaxCloseControl.xaml">
@@ -153,6 +149,7 @@
     <Page Include="AboutDialog.xaml" />
     <Page Include="SuggestionsControl.xaml" />
     <Page Include="SnippetsPaneContent.xaml" />
+    <Page Include="MarkdownPaneContent.xaml" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="app">

--- a/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
@@ -173,6 +173,14 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OpenConsoleDir)src\cascadia\inc;$(OpenConsoleDir)src\types\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</TreatWarningAsError>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</TreatWarningAsError>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</TreatWarningAsError>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</TreatWarningAsError>
+      <TreatSpecificWarningsAsErrors Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4189;4242;4389;4244</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Reference>
       <Private>false</Private>

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -8,6 +8,8 @@
 #include <shlobj.h>
 #include <WtExeUtils.h>
 
+#define ENV_WT_BASE_SETTINGS_PATH L"WT_BASE_SETTINGS_PATH"
+
 static constexpr std::wstring_view UnpackagedSettingsFolderName{ L"Microsoft\\Windows Terminal\\" };
 static constexpr std::wstring_view ReleaseSettingsFolder{ L"Packages\\Microsoft.WindowsTerminal_8wekyb3d8bbwe\\LocalState\\" };
 static constexpr std::wstring_view PortableModeMarkerFile{ L".portable" };
@@ -30,6 +32,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model
     std::filesystem::path GetBaseSettingsPath()
     {
         static auto baseSettingsPath = []() {
+            try
+            {
+                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                std::filesystem::create_directories(envSettingsPath);
+                return envSettingsPath;
+            }
+            CATCH_LOG()
+
             if (!IsPackaged() && IsPortableMode())
             {
                 std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
@@ -64,6 +74,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model
     std::filesystem::path GetReleaseSettingsPath()
     {
         static std::filesystem::path baseSettingsPath = []() {
+            try
+            {
+                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                std::filesystem::create_directories(envSettingsPath);
+                return envSettingsPath;
+            }
+            CATCH_LOG()
+
             wil::unique_cotaskmem_string localAppDataFolder;
             // We're using KF_FLAG_NO_PACKAGE_REDIRECTION to ensure that we always get the
             // user's actual local AppData directory.

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -24,6 +24,8 @@ using namespace ::Microsoft::Console;
 using namespace std::chrono_literals;
 using VirtualKeyModifiers = winrt::Windows::System::VirtualKeyModifiers;
 
+#define ENV_WT_BASE_SETTINGS_PATH L"WT_BASE_SETTINGS_PATH"
+
 #ifdef _WIN64
 static constexpr ULONG_PTR TERMINAL_HANDOFF_MAGIC = 0x4c414e494d524554; // 'TERMINAL'
 #else
@@ -296,6 +298,18 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), hash);
 #endif
     }
+
+    try
+    {
+        const auto settingsPath = wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH);
+        const auto settingsHash = til::hash(settingsPath);
+#ifdef _WIN64
+        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), settingsHash);
+#else
+        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), settingsHash);
+#endif
+    }
+    CATCH_LOG()
 
     // Windows Terminal is a single-instance application. Either acquire ownership
     // over the mutex, or hand off the command line to the existing instance.


### PR DESCRIPTION
Local state and multi instance with WT_BASE_SETTINGS_PATH env

## Summary by Sourcery

Introduces the WT_BASE_SETTINGS_PATH environment variable to allow users to specify a base settings path for Windows Terminal, enabling local state and multi-instance scenarios.

Enhancements:
- Adds support for the WT_BASE_SETTINGS_PATH environment variable to customize the settings path.
- Allows running multiple instances of Windows Terminal with different settings by using different WT_BASE_SETTINGS_PATH values.