### PR TITLE
Add command-line argument for local state directory

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -18,7 +18,7 @@
 
   <Identity Name="WindowsTerminalDev"
     Publisher="CN=Dm17tryK"
-    Version="1.24.53104.5" />
+    Version="1.25.53104.6" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreNameDev</DisplayName>

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -158,6 +158,9 @@ void AppCommandlineArgs::_buildParser()
         _shouldExitEarly = true;
     };
     _app.add_flag_function("-v,--version", versionCallback, RS_A(L"CmdVersionDesc"));
+    _app.add_option("-L,--localstate",
+                    _localState,
+                    RS_A(L"CmdLocalStateArgDesc"));
 
     // Launch mode related flags
     //   -M,--maximized: Maximizes the window on launch
@@ -1198,9 +1201,15 @@ void AppCommandlineArgs::FullResetState()
     _isHandoffListener = false;
 
     _windowTarget = {};
+    _localState = {};
 }
 
 std::string_view AppCommandlineArgs::GetTargetWindow() const noexcept
 {
     return _windowTarget;
+}
+
+std::string_view AppCommandlineArgs::GetLocalState() const noexcept
+{
+    return _localState;
 }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -49,6 +49,7 @@ public:
     void FullResetState();
 
     std::string_view GetTargetWindow() const noexcept;
+    std::string_view GetLocalState() const noexcept;
 
 private:
     static const std::wregex _commandDelimiterRegex;
@@ -139,6 +140,7 @@ private:
 
     int _loadPersistedLayoutIdx{};
     std::string _windowTarget{};
+    std::string _localState{};
     // Are you adding more args or attributes here? If they are not reset in _resetStateToDefault, make sure to reset them in FullResetState
 
     winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs _getNewTerminalArgs(NewTerminalSubcommand& subcommand);

--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -53,6 +53,11 @@ namespace winrt::TerminalApp::implementation
         return winrt::to_hstring(_parsed.GetTargetWindow());
     }
 
+    winrt::hstring CommandlineArgs::LocalState() const
+    {
+        return winrt::to_hstring(_parsed.GetLocalState());
+    }
+
     void CommandlineArgs::Commandline(const winrt::array_view<const winrt::hstring>& value)
     {
         _args = { value.begin(), value.end() };

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -24,6 +24,7 @@ namespace winrt::TerminalApp::implementation
         int32_t ExitCode() const noexcept;
         winrt::hstring ExitMessage() const;
         winrt::hstring TargetWindow() const;
+        winrt::hstring LocalState() const;
 
         void Commandline(const winrt::array_view<const winrt::hstring>& value);
         winrt::com_array<winrt::hstring> Commandline();
@@ -43,6 +44,7 @@ namespace winrt::TerminalApp::implementation
     {
         WINRT_PROPERTY(uint64_t, SourceWindow);
         WINRT_PROPERTY(uint64_t, TargetWindow);
+        WINRT_PROPERTY(uint64_t, LocalState);
         WINRT_PROPERTY(uint32_t, TabIndex);
 
     public:

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -44,7 +44,6 @@ namespace winrt::TerminalApp::implementation
     {
         WINRT_PROPERTY(uint64_t, SourceWindow);
         WINRT_PROPERTY(uint64_t, TargetWindow);
-        WINRT_PROPERTY(uint64_t, LocalState);
         WINRT_PROPERTY(uint32_t, TabIndex);
 
     public:

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -11,6 +11,7 @@ namespace TerminalApp
         Int32 ExitCode { get; };
         String ExitMessage { get; };
         String TargetWindow { get; };
+        String LocalState { get; };
 
         String[] Commandline;
         String CurrentDirectory { get; };
@@ -38,6 +39,7 @@ namespace TerminalApp
 
         UInt64 SourceWindow { get; };
         UInt64 TargetWindow { get; };
+        UInt64 LocalState { get; };
         UInt32 TabIndex { get; };
     };
 

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -39,7 +39,6 @@ namespace TerminalApp
 
         UInt64 SourceWindow { get; };
         UInt64 TargetWindow { get; };
-        UInt64 LocalState { get; };
         UInt32 TabIndex { get; };
     };
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -464,6 +464,9 @@
   <data name="CmdSavedLayoutArgDesc" xml:space="preserve">
     <value>This parameter is an internal implementation detail and should not be used.</value>
   </data>
+  <data name="CmdLocalStateArgDesc" xml:space="preserve">
+    <value>Local State folder path.</value>
+  </data>
   <data name="CmdWindowTargetArgDesc" xml:space="preserve">
     <value>Specify a terminal window to run the given commandline in. "0" always refers to the current window. </value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -34,9 +34,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model
         static auto baseSettingsPath = []() {
             try
             {
-                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
-                std::filesystem::create_directories(envSettingsPath);
-                return envSettingsPath;
+                std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                if (!envSettingsPath.empty())
+                {
+                    std::filesystem::create_directories(envSettingsPath);
+                    return envSettingsPath;
+                }
             }
             CATCH_LOG()
 
@@ -76,9 +79,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model
         static std::filesystem::path baseSettingsPath = []() {
             try
             {
-                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
-                std::filesystem::create_directories(envSettingsPath);
-                return envSettingsPath;
+                std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                if (!envSettingsPath.empty())
+                {
+                    std::filesystem::create_directories(envSettingsPath);
+                    return envSettingsPath;
+                }
             }
             CATCH_LOG()
 


### PR DESCRIPTION
## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)

## Summary by Sourcery

Add support for a new command-line argument to specify the local state directory for Windows Terminal

New Features:
- Introduce a new command-line option `-L` or `--localstate` to allow users to specify a custom local state directory for Windows Terminal

Enhancements:
- Modify command-line argument parsing to support the new local state option
- Update environment variable handling to use the new local state path