### PR TITLE
Improve text rendering, console output, and path translation

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -11,6 +11,7 @@ colorbrewer
 commandlines
 consvc
 copyable
+CText
 dalet
 dcs
 deselection

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -3114,12 +3114,13 @@
         },
         "pathTranslationStyle": {
           "default": "none",
-          "description": "Controls how file paths are transformed when they are dragged and dropped on the terminal. Possible values are \"none\", \"wsl\", \"cygwin\" and \"msys2\".",
+          "description": "Controls how file paths are transformed when they are dragged and dropped on the terminal. Possible values are \"none\", \"wsl\", \"cygwin\", \"msys2\" and \"mingw\".",
           "enum": [
             "none",
             "wsl",
             "cygwin",
-            "msys2"
+            "msys2",
+            "mingw"
           ],
           "type": "string"
         }

--- a/policies/WindowsTerminal.admx
+++ b/policies/WindowsTerminal.admx
@@ -9,6 +9,7 @@
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_WindowsTerminal_1_21" displayName="$(string.SUPPORTED_WindowsTerminal_1_21)" />
+      <definition name="SUPPORTED_DefaultTerminalApplication" displayName="$(string.SUPPORTED_DefaultTerminalApplication)" />
     </definitions>
   </supportedOn>
   <categories>
@@ -22,6 +23,62 @@
       <supportedOn ref="SUPPORTED_WindowsTerminal_1_21" />
       <elements>
         <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
+      </elements>
+    </policy>
+    <policy name="DefaultTerminalApplication" class="User" displayName="$(string.DefaultTerminalApplication)" explainText="$(string.DefaultTerminalApplicationText)" presentation="$(presentation.TermAppSelection)" key="Console\%%Startup">
+      <parentCategory ref="WindowsTerminal" />
+      <supportedOn ref="SUPPORTED_DefaultTerminalApplication" />
+      <elements>
+        <enum id="TermAppSelect" required="true" valueName="DelegationTerminal">
+          <item displayName="$(string.TermAppAutomatic)">
+            <value>
+              <string>{00000000-0000-0000-0000-000000000000}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{00000000-0000-0000-0000-000000000000}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.TermAppConsoleHost)">
+            <value>
+              <string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.TermAppWindowsTerminal)">
+            <value>
+              <string>{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.TermAppWindowsTerminalPreview)">
+            <value>
+              <string>{86633F1F-6454-40EC-89CE-DA4EBA977EE2}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{06EC847C-C0A5-46B8-92CB-7C92F6E35CD5}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+        </enum>
       </elements>
     </policy>
   </policies>

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -7,6 +7,7 @@
     <stringTable>
       <string id="WindowsTerminal">Windows Terminal</string>
       <string id="SUPPORTED_WindowsTerminal_1_21">At least Windows Terminal 1.21</string>
+      <string id="SUPPORTED_DefaultTerminalApplication">At least Windows 11 22H2 or Windows 10 22H2 (Build 19045.3031, KB5026435) with Windows Terminal 1.17</string>
       <string id="DisabledProfileSources">Disabled Profile Sources</string>
       <string id="DisabledProfileSourcesText">Profiles will not be generated from any sources listed here. Source names can be arbitrary strings. Potential candidates can be found as the "source" property on profile definitions in Windows Terminal's settings.json file.
 
@@ -18,10 +19,21 @@ Common sources are:
 For instance, setting this policy to Windows.Terminal.Wsl will disable the builtin WSL integration of Windows Terminal.
 
 Note: Existing profiles will disappear from Windows Terminal after adding their source to this policy.</string>
+      <string id="DefaultTerminalApplication">Default terminal application</string>
+      <string id="DefaultTerminalApplicationText">Select the default terminal application used in Windows.
+
+If you select Windows Terminal Preview and it is not installed the system will fallback to the legacy Windows Console Host. (Please note that the settings interfaces showing "Let windows decide" in this case as configuration.)</string>
+      <string id="TermAppAutomatic">Automatic selection (Windows Terminal, if available)</string>
+      <string id="TermAppConsoleHost">Windows Console Host (legacy)</string>
+      <string id="TermAppWindowsTerminal">Windows Terminal</string>
+      <string id="TermAppWindowsTerminalPreview">Windows Terminal Preview (if available)</string>
     </stringTable>
     <presentationTable>
       <presentation id="DisabledProfileSources">
         <multiTextBox refId="DisabledProfileSources">List of disabled sources (one per line)</multiTextBox>
+      </presentation>
+      <presentation id="TermAppSelection">
+        <dropdownList refId="TermAppSelect" noSort="true" defaultItem="0">Select from the following options:</dropdownList>
       </presentation>
     </presentationTable>
   </resources>

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2061,14 +2061,6 @@ void TextBuffer::_ExpandTextRow(til::inclusive_rect& textRow) const
     }
 }
 
-size_t TextBuffer::SpanLength(const til::point coordStart, const til::point coordEnd) const
-{
-    const auto bufferSize = GetSize();
-    // The coords are inclusive, so to get the (inclusive) length we add 1.
-    const auto length = bufferSize.CompareInBounds(coordEnd, coordStart) + 1;
-    return gsl::narrow<size_t>(length);
-}
-
 // Routine Description:
 // - Retrieves the plain text data between the specified coordinates.
 // Arguments:

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -199,8 +199,6 @@ public:
     std::wstring GetCustomIdFromId(uint16_t id) const;
     void CopyHyperlinkMaps(const TextBuffer& OtherBuffer);
 
-    size_t SpanLength(const til::point coordStart, const til::point coordEnd) const;
-
     std::wstring GetPlainText(til::point start, til::point end) const;
 
     struct CopyRequest

--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -17,7 +17,7 @@ namespace winrt::TerminalApp::implementation
 {
     CommandlineArgs::CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString) :
         _args{ args.begin(), args.end() },
-        _cwd{ std::move(currentDirectory) },
+        CurrentDirectory{ std::move(currentDirectory) },
         ShowWindowCommand{ showWindowCommand },
         CurrentEnvironment{ std::move(envString) }
     {

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -36,7 +36,6 @@ namespace winrt::TerminalApp::implementation
         ::TerminalApp::AppCommandlineArgs _parsed;
         int32_t _parseResult = 0;
         winrt::com_array<winrt::hstring> _args;
-        winrt::hstring _cwd;
     };
 
     struct RequestReceiveContentArgs : RequestReceiveContentArgsT<RequestReceiveContentArgs>

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -230,6 +230,7 @@
                               VerticalScrollMode="Enabled"
                               Visibility="Visible">
                     <TextBlock x:Name="_descriptionComment"
+                               Margin="0,0,20,0"
                                IsTextSelectionEnabled="True"
                                TextWrapping="WrapWholeWords" />
                 </ScrollViewer>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -563,8 +563,11 @@ namespace winrt::TerminalApp::implementation
                 _WindowProperties.VirtualEnvVars(originalVirtualEnv);
             }
         });
-        _WindowProperties.VirtualWorkingDirectory(cwd);
-        _WindowProperties.VirtualEnvVars(env);
+        if (!cwd.empty())
+        {
+            _WindowProperties.VirtualWorkingDirectory(cwd);
+            _WindowProperties.VirtualEnvVars(env);
+        }
 
         for (size_t i = 0; i < actions.size(); ++i)
         {

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -428,6 +428,20 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             TerminalOutput.raise(L"\r\n");
             TerminalOutput.raise(badPathText);
         }
+        // If the requested action requires elevation, display appropriate message
+        else if (hr == HRESULT_FROM_WIN32(ERROR_ELEVATION_REQUIRED))
+        {
+            const auto elevationText = RS_(L"ElevationRequired");
+            TerminalOutput.raise(L"\r\n");
+            TerminalOutput.raise(elevationText);
+        }
+        // If the requested executable was not found, display appropriate message
+        else if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+        {
+            const auto fileNotFoundText = RS_(L"FileNotFound");
+            TerminalOutput.raise(L"\r\n");
+            TerminalOutput.raise(fileNotFoundText);
+        }
 
         _transitionToState(ConnectionState::Failed);
 

--- a/src/cascadia/TerminalConnection/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/de-DE/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Sie können dieses Terminal jetzt mit STRG+D schließen oder zum Neustart die EINGABETASTE drücken.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[Fehler {0} beim Start von `{1}']</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Auf das Startverzeichnis „{0}“ konnte nicht zugegriffen werden</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>Für den angeforderten Vorgang sind erhöhte Rechte erforderlich.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Die angegebene Datei wurde nicht gefunden.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>You can now close this terminal with Ctrl+D, or press Enter to restart.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[error {0} when launching `{1}']</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Could not access starting directory "{0}"</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>The requested operation requires elevation.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>The system cannot find the file specified.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/es-ES/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Ahora puede cerrar este terminal con Ctrl+D o presionar Entrar para reiniciar.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[error {0} al iniciar `{1}']</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>No se pudo obtener acceso al directorio inicial «{0}»</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>La operación solicitada requiere elevación.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>El sistema no puede encontrar el archivo especificado.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/fr-FR/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Vous pouvez maintenant fermer ce terminal avec Ctrl+D, ou appuyez sur Entrée pour redémarrer.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[erreur {0} lors du lancement de `{1}']</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Le démarrage du répertoire n’est pas accessible «{0}»</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>L’opération demandée nécessite une élévation.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Le fichier spécifié est introuvable.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/it-IT/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>È ora possibile chiudere il terminale con CTRL+D oppure premere INVIO per riavviarlo.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[errore {0} durante l'avvio di `{1}']</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Non è possibile accedere alla directory di avvio "{0}"</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>Per l'operazione richiesta è necessaria l'elevazione dei privilegi.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Impossibile trovare il file specificato.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/ja-JP/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>このターミナルを Ctrl+D で閉じるか、Enter キーを押して再起動できます。</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>['{1}' の起動時にエラー {0} が発生しました]</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>先頭のディレクトリ "{0}" にアクセスできませんでした</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>要求された操作には、権限の昇格が必要です。</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>指定されたファイルが見つかりません。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/ko-KR/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>이제 Ctrl+D 이 터미널을 닫거나 Enter 키를 눌러 다시 시작할 수 있습니다.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[’{1}' 시작 시 {0} 오류 발생]</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>시작 디렉터리 "{0}"에 액세스할 수 없습니다.</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>요청한 작업을 수행하려면 권한 상승이 필요합니다.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>시스템에서 지정된 파일을 찾을 수 없습니다.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/pt-BR/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Agora você pode fechar este terminal com Ctrl+D ou pressione Enter para reiniciar.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[erro {0} ao iniciar "{1}"]</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Não foi possível acessar o diretório inicial "{0}"</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>A operação solicitada exige elevação.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>O sistema não pode encontrar o arquivo especificado.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/qps-ploc/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Ỳóŭ ćǻή иòω сĺøѕè ťнįş тёѓмîήªŀ ωīťђ Çťѓℓ+Ď, όг ргéšѕ Σñтèř το ґèšтªят. !!! !!! !!! !!! !!! !!! !!!</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[℮ѓѓŏŕ {0} ωĥєй łåύñćђίηğ `{1}'] !!! !!! !!! </value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Ċőŭľđ йōť ª¢čеѕş şτāŗťΐиğ ðιѓεςтоŗγ "{0}" !!! !!! !!! !!!</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>Ţнė ŗēqμĕѕŧєđ ôφ℮ґάтĩöй ŕєqΰїŗęś ėĺęνáτîøŋ. !!! !!! !!! !!! </value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Ŧнё şγśţêм ςâлηόť ƒїлď ŧнэ ƒΐĺë śрéćιƒієð. !!! !!! !!! !!! </value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/qps-ploca/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Ỳóŭ ćǻή иòω сĺøѕè ťнįş тёѓмîήªŀ ωīťђ Çťѓℓ+Ď, όг ргéšѕ Σñтèř το ґèšтªят. !!! !!! !!! !!! !!! !!! !!!</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[℮ѓѓŏŕ {0} ωĥєй łåύñćђίηğ `{1}'] !!! !!! !!! </value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Ċőŭľđ йōť ª¢čеѕş şτāŗťΐиğ ðιѓεςтоŗγ "{0}" !!! !!! !!! !!!</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>Ţнė ŗēqμĕѕŧєđ ôφ℮ґάтĩöй ŕєqΰїŗęś ėĺęνáτîøŋ. !!! !!! !!! !!! </value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Ŧнё şγśţêм ςâлηόť ƒїлď ŧнэ ƒΐĺë śрéćιƒієð. !!! !!! !!! !!! </value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/qps-plocm/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Ỳóŭ ćǻή иòω сĺøѕè ťнįş тёѓмîήªŀ ωīťђ Çťѓℓ+Ď, όг ргéšѕ Σñтèř το ґèšтªят. !!! !!! !!! !!! !!! !!! !!!</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[℮ѓѓŏŕ {0} ωĥєй łåύñćђίηğ `{1}'] !!! !!! !!! </value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Ċőŭľđ йōť ª¢čеѕş şτāŗťΐиğ ðιѓεςтоŗγ "{0}" !!! !!! !!! !!!</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>Ţнė ŗēqμĕѕŧєđ ôφ℮ґάтĩöй ŕєqΰїŗęś ėĺęνáτîøŋ. !!! !!! !!! !!! </value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Ŧнё şγśţêм ςâлηόť ƒїлď ŧнэ ƒΐĺë śрéćιƒієð. !!! !!! !!! !!! </value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/ru-RU/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>Теперь вы можете закрыть этот терминал с помощью клавиш CTRL+D. Или нажмите клавишу ВВОД для перезапуска.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[ошибка {0} при запуске "{1}"]</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Не удалось получить доступ к запуску каталога "{0}"</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>Запрошенная операция требует получения дополнительных прав.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>Не удается найти указанный файл.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/zh-CN/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>现在可以使用Ctrl+D关闭此终端，或按 Enter 重新启动。</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[出现错误 {0} (启动“{1}”时)]</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>无法访问启动目录“{0}”</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>请求的操作需要提升。</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>系统找不到指定的文件。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/zh-TW/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>您現在可以使用 Ctrl+D 關閉此終端機，或按 Enter 重新啟動。</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[啟動 `{1}' 時發生錯誤 {0}]</value>
@@ -219,5 +219,11 @@
   <data name="BadPathText" xml:space="preserve">
     <value>無法存取開始目錄 "{0}"</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>要求的操作需要提高權限。</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>系統找不到指定的檔案。</value>
   </data>
 </root>

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2868,6 +2868,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 // coloring other matches, then we need to make sure those get redrawn,
                 // too.
                 _renderer->TriggerRedrawAll();
+                _updateSelectionUI();
             }
         }
     }

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -26,7 +26,8 @@ namespace Microsoft.Terminal.Control
         None = 0,
         WSL,
         Cygwin,
-        MSYS2
+        MSYS2,
+        MinGW,
     };
 
     // Class Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -97,6 +97,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             /* WSL */ L"/mnt/",
             /* Cygwin */ L"/cygdrive/",
             /* MSYS2 */ L"/",
+            /* MinGW */ {},
         };
         static constexpr wil::zwstring_view sSingleQuoteEscape = L"'\\''";
         static constexpr auto cchSingleQuoteEscape = sSingleQuoteEscape.size();
@@ -117,6 +118,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             fullPath.replace(pos, 1, sSingleQuoteEscape);
             // Arithmetic overflow cannot occur here.
             pos += cchSingleQuoteEscape;
+        }
+
+        if (translationStyle == PathTranslationStyle::MinGW)
+        {
+            return;
         }
 
         if (fullPath.size() >= 2 && fullPath.at(1) == L':')

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1571,10 +1571,10 @@ void Terminal::SerializeMainBuffer(const wchar_t* destination) const
 
 void Terminal::ColorSelection(const TextAttribute& attr, winrt::Microsoft::Terminal::Core::MatchMode matchMode)
 {
-    const auto colorSelection = [this](const til::point coordStart, const til::point coordEnd, const TextAttribute& attr) {
+    const auto colorSelection = [this](const til::point coordStartInclusive, const til::point coordEndExclusive, const TextAttribute& attr) {
         auto& textBuffer = _activeBuffer();
-        const auto spanLength = textBuffer.SpanLength(coordStart, coordEnd);
-        textBuffer.Write(OutputCellIterator(attr, spanLength), coordStart);
+        const auto spanLength = textBuffer.GetSize().CompareInBounds(coordEndExclusive, coordStartInclusive, true);
+        textBuffer.Write(OutputCellIterator(attr, spanLength), coordStartInclusive);
     };
 
     for (const auto [start, end] : _GetSelectionSpans())

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Profil wird nicht mehr erkannt</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2316,6 +2316,10 @@
     <value>MSYS2 (C:\ -> /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -> C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Profile no longer detected</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>El perfil ya no se ha detectado</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Le profil n’est plus détecté</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Profilo non più rilevato</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>プロファイルは検出されなくなりました</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2(C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW(C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>프로필이 더 이상 검색되지 않음</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Perfil não detectado</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2317,7 +2317,7 @@
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
-    <value>MinGW (C:\ -&gt; C:/)</value>
+    <value>MinGW (C:\ -&gt; C:/) !!! !!</value>
     <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2316,6 +2316,10 @@
     <value>MSYS2 (C:\ -&gt; /c) !!! !!</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Ρřσƒīŀē ⁿο łøňġèя ðёτęςτęď !!! !!! !</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2317,7 +2317,7 @@
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
-    <value>MinGW (C:\ -&gt; C:/)</value>
+    <value>MinGW (C:\ -&gt; C:/) !!! !!</value>
     <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2316,6 +2316,10 @@
     <value>MSYS2 (C:\ -&gt; /c) !!! !!</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Ρřσƒīŀē ⁿο łøňġèя ðёτęςτęď !!! !!! !</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2317,7 +2317,7 @@
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
-    <value>MinGW (C:\ -&gt; C:/)</value>
+    <value>MinGW (C:\ -&gt; C:/) !!! !!</value>
     <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2316,6 +2316,10 @@
     <value>MSYS2 (C:\ -&gt; /c) !!! !!</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Ρřσƒīŀē ⁿο łøňġèя ðёτęςτęď !!! !!! !</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Профиль больше не обнаруживается</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>不再检测到配置文件</value>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2312,6 +2312,10 @@
     <value>MSYS2 (C:\ -&gt; /c)</value>
     <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
+  <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
+    <value>MinGW (C:\ -&gt; C:/)</value>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
+  </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>已不再偵測到設定檔</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -794,10 +794,11 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Control::DefaultInputScope)
 
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Control::PathTranslationStyle)
 {
-    static constexpr std::array<pair_type, 4> mappings = {
+    static constexpr std::array<pair_type, 5> mappings = {
         pair_type{ "none", ValueType::None },
         pair_type{ "wsl", ValueType::WSL },
         pair_type{ "cygwin", ValueType::Cygwin },
         pair_type{ "msys2", ValueType::MSYS2 },
+        pair_type{ "mingw", ValueType::MinGW },
     };
 };

--- a/src/host/_output.cpp
+++ b/src/host/_output.cpp
@@ -110,15 +110,25 @@ static FillConsoleResult FillConsoleImpl(SCREEN_INFORMATION& screenInfo, FillCon
             switch (mode)
             {
             case FillConsoleMode::WriteAttribute:
+            {
                 for (; columns < columnsAvailable && inputPos < lengthToWrite; ++columns, ++inputPos)
                 {
-                    infoBuffer[columns].Attributes = input[inputPos];
+                    // Overwrite all attributes except for the lead/trail byte markers.
+                    // Those are used by WriteConsoleOutputWImplHelper to correctly serialize the input.
+                    constexpr auto LT = COMMON_LVB_LEADING_BYTE | COMMON_LVB_TRAILING_BYTE;
+                    auto& attributes = infoBuffer[columns].Attributes;
+                    attributes = (input[inputPos] & ~LT) | (attributes & LT);
                 }
                 break;
+            }
             case FillConsoleMode::FillAttribute:
                 for (const auto attr = input[0]; columns < columnsAvailable && inputPos < lengthToWrite; ++columns, ++inputPos)
                 {
-                    infoBuffer[columns].Attributes = attr;
+                    // Overwrite all attributes except for the lead/trail byte markers.
+                    // Those are used by WriteConsoleOutputWImplHelper to correctly serialize the input.
+                    constexpr auto LT = COMMON_LVB_LEADING_BYTE | COMMON_LVB_TRAILING_BYTE;
+                    auto& attributes = infoBuffer[columns].Attributes;
+                    attributes = (attr & ~LT) | (attributes & LT);
                 }
                 break;
             case FillConsoleMode::WriteCharacter:

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -1119,12 +1119,33 @@ void COOKED_READ_DATA::_redisplay()
         output.append(L"\x1b[J");
     }
 
-    // Disable the cursor when opening a popup, reenable it when closing them.
+    // Backup the attributes (DECSC) and disable the cursor when opening a popup (DECTCEM).
+    // Restore the attributes (DECRC) reenable the cursor when closing them (DECTCEM).
     if (const auto popupOpened = !_popups.empty(); _popupOpened != popupOpened)
     {
-        wchar_t buf[] = L"\x1b[?25l";
-        buf[5] = popupOpened ? 'l' : 'h';
-        output.append(&buf[0], 6);
+        wchar_t buf[] =
+            // Back/restore cursor position & attributes (commonly supported)
+            L"\u001b7"
+            // Show/hide cursor (commonly supported)
+            "\u001b[?25l"
+            // The popup code uses XTPUSHSGR (CSI # {) / XTPOPSGR (CSI # }) to draw the popups in the popup-colors,
+            // while properly restoring the previous VT attributes. On terminals that support them, the following
+            // won't do anything. On other terminals however, it'll reset the attributes to default.
+            // This is important as the first thing the popup drawing code uses CSI K to erase the previous contents
+            // and CSI m to reset the attributes on terminals that don't support XTPUSHSGR/XTPOPSGR. In order for
+            // the first CSI K to behave as if there had a previous CSI m, we must emit an initial CSI m here.
+            // (rarely supported)
+            "\x1b[#{\x1b[m\x1b[#}";
+
+        buf[1] = popupOpened ? '7' : '8';
+        buf[7] = popupOpened ? 'l' : 'h';
+
+        // When the popup closes we skip the XTPUSHSGR/XTPOPSGR sequence. This is crucial because we
+        // use DECRC to restore the cursor position and attributes with a widely supported sequence.
+        // If we emitted that XTPUSHSGR/XTPOPSGR sequence it would reset the attributes again.
+        const size_t len = popupOpened ? 19 : 8;
+
+        output.append(buf, len);
         _popupOpened = popupOpened;
     }
 
@@ -1595,10 +1616,10 @@ void COOKED_READ_DATA::_popupDrawPrompt(std::vector<Line>& lines, const til::Coo
     str.append(suffix);
 
     std::wstring line;
-    line.append(L"\x1b[K");
+    line.append(L"\x1b[#{\x1b[K");
     _appendPopupAttr(line);
     const auto res = _layoutLine(line, str, 0, 0, width);
-    line.append(L"\x1b[m");
+    line.append(L"\x1b[m\x1b[#}");
 
     lines.emplace_back(std::move(line), 0, 0, res.column);
 }
@@ -1654,7 +1675,7 @@ void COOKED_READ_DATA::_popupDrawCommandList(std::vector<Line>& lines, const til
         const auto selected = index == cl.selected && !stackedCommandNumberPopup;
 
         std::wstring line;
-        line.append(L"\x1b[K");
+        line.append(L"\x1b[#{\x1b[K");
         _appendPopupAttr(line);
 
         wchar_t scrollbarChar = L' ';
@@ -1681,7 +1702,7 @@ void COOKED_READ_DATA::_popupDrawCommandList(std::vector<Line>& lines, const til
         }
         else
         {
-            line.append(L"\x1b[m ");
+            line.append(L"\x1b[m\x1b[#} ");
         }
 
         fmt::format_to(std::back_inserter(line), FMT_COMPILE(L"{:{}}: "), index, indexWidth);
@@ -1690,7 +1711,7 @@ void COOKED_READ_DATA::_popupDrawCommandList(std::vector<Line>& lines, const til
 
         if (selected)
         {
-            line.append(L"\x1b[m");
+            line.append(L"\x1b[m\x1b[#}");
         }
 
         line.append(L"\r\n");

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -52,6 +52,16 @@ static constexpr std::wstring_view s_initialContentVT{
     // clang-format on
 };
 
+static constexpr std::wstring_view s_initialContentVTWide{
+    // clang-format off
+    L""
+    sgr_red("〇") sgr_blu("一") sgr_red("二") sgr_blu("三") "\r\n"
+    sgr_red("四") sgr_blu("五") sgr_red("六") sgr_blu("七") "\r\n"
+    sgr_blu("八") sgr_red("九") sgr_blu("十") sgr_red("百") "\r\n"
+    sgr_blu("千") sgr_red("万") sgr_blu("億") sgr_red("兆")
+    // clang-format on
+};
+
 class ::Microsoft::Console::VirtualTerminal::VtIoTests
 {
     BEGIN_TEST_CLASS(VtIoTests)
@@ -71,11 +81,11 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         return { &rxBuf[0], read };
     }
 
-    void setupInitialContents() const
+    void setupInitialContents(bool wide) const
     {
         auto& sm = screenInfo->GetStateMachine();
         sm.ProcessString(L"\033c");
-        sm.ProcessString(s_initialContentVT);
+        sm.ProcessString(wide ? s_initialContentVTWide : s_initialContentVT);
         sm.ProcessString(L"\x1b[H" sgr_rst());
     }
 
@@ -277,7 +287,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
 
     TEST_METHOD(WriteConsoleOutputAttribute)
     {
-        setupInitialContents();
+        setupInitialContents(false);
 
         static constexpr std::array payload{ red, blu, red, blu };
         static constexpr til::point target{ 6, 1 };
@@ -295,7 +305,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
 
     TEST_METHOD(WriteConsoleOutputCharacterW)
     {
-        setupInitialContents();
+        setupInitialContents(false);
 
         size_t written = 0;
         std::string_view expected;
@@ -354,7 +364,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         actual = readOutput();
         VERIFY_ARE_EQUAL(expected, actual);
 
-        setupInitialContents();
+        setupInitialContents(false);
 
         // Writing at the start of a line.
         THROW_IF_FAILED(routines.FillConsoleOutputAttributeImpl(*screenInfo, red, 3, { 0, 0 }, cellsModified, false));
@@ -388,6 +398,25 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         VERIFY_ARE_EQUAL(expected, actual);
     }
 
+    TEST_METHOD(FillConsoleOutputAttributeWide)
+    {
+        setupInitialContents(true);
+
+        size_t cellsModified = 0;
+        std::string_view expected;
+        std::string_view actual;
+
+        // Writing nothing should produce nothing.
+        THROW_IF_FAILED(routines.FillConsoleOutputAttributeImpl(*screenInfo, red, 4, { 2, 1 }, cellsModified, false));
+        expected =
+            decsc() //
+            cup(2, 3) sgr_red("五六") //
+            decrc();
+        actual = readOutput();
+        VERIFY_ARE_EQUAL(4u, cellsModified);
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
     TEST_METHOD(FillConsoleOutputCharacterW)
     {
         size_t cellsModified = 0;
@@ -407,7 +436,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         actual = readOutput();
         VERIFY_ARE_EQUAL(expected, actual);
 
-        setupInitialContents();
+        setupInitialContents(false);
 
         // Writing at the start of a line.
         THROW_IF_FAILED(routines.FillConsoleOutputCharacterWImpl(*screenInfo, L'a', 3, { 0, 0 }, cellsModified, false));
@@ -453,7 +482,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         std::string_view expected;
         std::string_view actual;
 
-        setupInitialContents();
+        setupInitialContents(false);
 
         // Scrolling from nowhere to somewhere are no-ops and should not emit anything.
         THROW_IF_FAILED(routines.ScrollConsoleScreenBufferWImpl(*screenInfo, { 0, 0, -1, -1 }, {}, std::nullopt, L' ', 0, false));
@@ -487,7 +516,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         //
         //   m   n   M   N   o   p   O   P
         //
-        setupInitialContents();
+        setupInitialContents(false);
 
         // Scrolling from somewhere to somewhere.
         //
@@ -626,7 +655,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         std::string_view expected;
         std::string_view actual;
 
-        setupInitialContents();
+        setupInitialContents(false);
 
         // Scrolling from nowhere to somewhere are no-ops and should not emit anything.
         THROW_IF_FAILED(routines.ScrollConsoleScreenBufferWImpl(*screenInfo, { 0, 0, -1, -1 }, {}, std::nullopt, L' ', 0, false));
@@ -660,7 +689,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
         //
         //   m   n   M   N   o   p   O   P
         //
-        setupInitialContents();
+        setupInitialContents(false);
 
         // Scrolling from somewhere to somewhere.
         //
@@ -797,7 +826,7 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
             &screenInfoAlt));
 
         routines.SetConsoleActiveScreenBufferImpl(*screenInfoAlt);
-        setupInitialContents();
+        setupInitialContents(false);
         THROW_IF_FAILED(routines.SetConsoleOutputModeImpl(*screenInfoAlt, ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING));
         readOutput();
 


### PR DESCRIPTION
## Summary by Sourcery

Improve text rendering, console output handling, and path translation with various enhancements across the Windows Terminal codebase

Bug Fixes:
- Fix newline and carriage return handling to prevent duplicate CR characters
- Preserve lead/trail byte markers when modifying console attributes
- Improve error message handling for elevation and file not found scenarios

Enhancements:
- Enhance wide character and multi-byte text rendering support in console output functions
- Improve cursor and attribute handling during popup interactions
- Add support for MinGW path translation style

Tests:
- Add test cases for wide character text rendering
- Extend VT IO tests to cover more complex text rendering scenarios