### PR TITLE
Add project name support

### DIFF
--- a/BuildWT.ps1
+++ b/BuildWT.ps1
@@ -179,7 +179,7 @@ if (-not $NoPackage -and $Bundle) {
         Invoke-Expression $makeappxCmd
 
         # Sign the bundle using signtool
-        $certPath = ".\WindowsTerminal.pfx"
+        $certPath = ".\Dm17tryK.pfx"
         if (Test-Path $certPath) {
             # Prompt for the certificate password securely
             $certPassword = Read-Host -AsSecureString "Enter the password for the certificate"

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -1,181 +1,207 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
-
   <PropertyGroup Label="NuGet Dependencies">
-    <TerminalMUX>true</TerminalMUX>
+	<TerminalMUX>true</TerminalMUX>
   </PropertyGroup>
   <Import Project="$(OpenConsoleDir)src\wap-common.build.pre.props" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <PropertyGroup Label="Configuration">
-    <!--
-    These two properties are very important!
-    Without them, msbuild will stomp MinVersion and MaxVersionTested in the
-    Package.appxmanifest and replace them with whatever our values for
-    TargetPlatformMinVersion and TargetPlatformVersion are.
-     -->
-    <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
-    <AppxOSMaxVersionTestedReplaceManifestVersion>false</AppxOSMaxVersionTestedReplaceManifestVersion>
-    <OCExecutionAliasName Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">wtd</OCExecutionAliasName>
-    <OCExecutionAliasName Condition="'$(OCExecutionAliasName)'==''">wt</OCExecutionAliasName>
+	<!--
+	These two properties are very important!
+	Without them, msbuild will stomp MinVersion and MaxVersionTested in the
+	Package.appxmanifest and replace them with whatever our values for
+	TargetPlatformMinVersion and TargetPlatformVersion are.
+	 -->
+	<AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
+	<AppxOSMaxVersionTestedReplaceManifestVersion>false</AppxOSMaxVersionTestedReplaceManifestVersion>
+	<OCExecutionAliasName Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">wtd</OCExecutionAliasName>
+	<OCExecutionAliasName Condition="'$(OCExecutionAliasName)'==''">wt</OCExecutionAliasName>
   </PropertyGroup>
   <PropertyGroup>
-    <ProjectGuid>CA5CAD1A-224A-4171-B13A-F16E576FDD12</ProjectGuid>
-    <EntryPointProjectUniqueName>..\WindowsTerminal\WindowsTerminal.vcxproj</EntryPointProjectUniqueName>
-    <DebuggerType>NativeOnly</DebuggerType>
+	<ProjectGuid>CA5CAD1A-224A-4171-B13A-F16E576FDD12</ProjectGuid>
+	<EntryPointProjectUniqueName>..\WindowsTerminal\WindowsTerminal.vcxproj</EntryPointProjectUniqueName>
+	<DebuggerType>NativeOnly</DebuggerType>
   </PropertyGroup>
   <PropertyGroup Condition="!Exists('CascadiaPackage_TemporaryKey.pfx')">
-    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
-    <AppxBundle>Never</AppxBundle>
+	<AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+	<AppxBundle>Never</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="Exists('CascadiaPackage_TemporaryKey.pfx')">
-    <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
-    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
-    <PackageCertificateKeyFile>CascadiaPackage_TemporaryKey.pfx</PackageCertificateKeyFile>
+	<AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
+	<AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
+	<PackageCertificateKeyFile>CascadiaPackage_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <ItemGroup Condition="Exists('CascadiaPackage_TemporaryKey.pfx')">
-    <None Include="CascadiaPackage_TemporaryKey.pfx" />
+	<None Include="CascadiaPackage_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Release'">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-    <AppxManifest Include="Package-Pre.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Preview'">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-    <AppxManifest Include="Package-Can.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Canary'">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">
-      <SubType>Designer</SubType>
-    </AppxManifest>
+	<AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Release'">
+	  <SubType>Designer</SubType>
+	</AppxManifest>
+	<AppxManifest Include="Package-Pre.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Preview'">
+	  <SubType>Designer</SubType>
+	</AppxManifest>
+	<AppxManifest Include="Package-Can.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Canary'">
+	  <SubType>Designer</SubType>
+	</AppxManifest>
+	<AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">
+	  <SubType>Designer</SubType>
+	</AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <!-- Resources -->
-    <!-- This resw only defines things that are used in this package's AppxManifest,
-         so it's not in the common resource items. -->
-    <PRIResource Include="Resources\en-US\Resources.resw" />
-    <PRIResource Include="Resources\Resources.resw" />
-    <OCResourceDirectory Include="Resources" />
+	<!-- Resources -->
+	<!-- This resw only defines things that are used in this package's AppxManifest,
+		 so it's not in the common resource items. -->
+	<PRIResource Include="Resources\en-US\Resources.resw" />
+	<PRIResource Include="Resources\Resources.resw" />
+	<OCResourceDirectory Include="Resources" />
   </ItemGroup>
-
   <!-- This is picked up by CascadiaResources.build.items. -->
   <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">
-    <WindowsTerminalAssetSuffix>-Dev</WindowsTerminalAssetSuffix>
+	<WindowsTerminalAssetSuffix>-Dev</WindowsTerminalAssetSuffix>
   </PropertyGroup>
   <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Preview'">
-    <WindowsTerminalAssetSuffix>-Pre</WindowsTerminalAssetSuffix>
+	<WindowsTerminalAssetSuffix>-Pre</WindowsTerminalAssetSuffix>
   </PropertyGroup>
   <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Canary'">
-    <WindowsTerminalAssetSuffix>-Can</WindowsTerminalAssetSuffix>
+	<WindowsTerminalAssetSuffix>-Can</WindowsTerminalAssetSuffix>
   </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)..\CascadiaResources.build.items" />
   <Import Project="$(OpenConsoleDir)src\wap-common.build.post.props" />
-
   <ItemGroup>
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\WindowsTerminal\WindowsTerminal.vcxproj">
-      <Project>{CA5CAD1A-1754-4A9D-93D7-857A9D17CB1B}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalAzBridge\TerminalAzBridge.vcxproj">
-      <Project>{067F0A06-FCB7-472C-96E9-B03B54E8E18D}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\ShellExtension\WindowsTerminalShellExt.vcxproj">
-      <Project>{f2ed628a-db22-446f-a081-4cc845b51a2b}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\wt\wt.vcxproj">
-      <Project>{506fd703-baa7-4f6e-9361-64f550ec8fca}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\host\exe\Host.EXE.vcxproj">
-      <Project>{9CBD7DFA-1754-4A9D-93D7-857A9D17CB1B}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\ElevateShim\elevate-shim.vcxproj" >
-      <Project>{416fd703-baa7-4f6e-9361-64f550ec8fca}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\host\proxy\Host.Proxy.vcxproj">
-      <Project>{71CC9D78-BA29-4D93-946F-BEF5D9A3A6EF}</Project>
-    </ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\cascadia\WindowsTerminal\WindowsTerminal.vcxproj">
+	  <Project>{CA5CAD1A-1754-4A9D-93D7-857A9D17CB1B}</Project>
+	</ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalAzBridge\TerminalAzBridge.vcxproj">
+	  <Project>{067F0A06-FCB7-472C-96E9-B03B54E8E18D}</Project>
+	</ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\cascadia\ShellExtension\WindowsTerminalShellExt.vcxproj">
+	  <Project>{f2ed628a-db22-446f-a081-4cc845b51a2b}</Project>
+	</ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\cascadia\wt\wt.vcxproj">
+	  <Project>{506fd703-baa7-4f6e-9361-64f550ec8fca}</Project>
+	</ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\host\exe\Host.EXE.vcxproj">
+	  <Project>{9CBD7DFA-1754-4A9D-93D7-857A9D17CB1B}</Project>
+	</ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\cascadia\ElevateShim\elevate-shim.vcxproj">
+	  <Project>{416fd703-baa7-4f6e-9361-64f550ec8fca}</Project>
+	</ProjectReference>
+	<ProjectReference Include="$(OpenConsoleDir)src\host\proxy\Host.Proxy.vcxproj">
+	  <Project>{71CC9D78-BA29-4D93-946F-BEF5D9A3A6EF}</Project>
+	</ProjectReference>
   </ItemGroup>
-
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+	<Content Include="C:\Users\dmitr\src\WTLayoutManager\third_party\detours\Release\bin.X64\WTLocalStateHook64.dll">
+	  <Link>WTLocalStateHook64.dll</Link>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+	<Content Include="C:\Users\dmitr\src\WTLayoutManager\third_party\detours\Debug\bin.X64\WTLocalStateHook64.dll">
+	  <Link>WTLocalStateHook64.dll</Link>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+	<Content Include="C:\Users\dmitr\src\WTLayoutManager\third_party\detours\Release\bin.ARM64\WTLocalStateHook64.dll">
+	  <Link>WTLocalStateHook64.dll</Link>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+	<Content Include="C:\Users\dmitr\src\WTLayoutManager\third_party\detours\Debug\bin.ARM64\WTLocalStateHook64.dll">
+	  <Link>WTLocalStateHook64.dll</Link>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+	<Content Include="C:\Users\dmitr\src\WTLayoutManager\third_party\detours\Release\bin.X86\WTLocalStateHook32.dll">
+	  <Link>WTLocalStateHook32.dll</Link>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+	<Content Include="C:\Users\dmitr\src\WTLayoutManager\third_party\detours\Debug\bin.X86\WTLocalStateHook32.dll">
+	  <Link>WTLocalStateHook32.dll</Link>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
   <Target Name="OpenConsoleStompSourceProjectForWapProject" BeforeTargets="_ConvertItems">
-    <ItemGroup>
-      <!-- Stomp all "SourceProject" values for all incoming dependencies to flatten the package. -->
-      <_TemporaryFilteredWapProjOutput Include="@(_FilteredNonWapProjProjectOutput)" />
-      <_FilteredNonWapProjProjectOutput Remove="@(_TemporaryFilteredWapProjOutput)" />
-      <_FilteredNonWapProjProjectOutput Include="@(_TemporaryFilteredWapProjOutput)">
-        <!-- Blank the SourceProject here to vend all files into the root of the package. -->
-        <SourceProject>
-        </SourceProject>
-        <!-- Replace the filename for wt/wtd.exe with the one the manifest wants. -->
-        <TargetPath Condition="'%(Filename)' == 'wt' and '%(Extension)' == '.exe'">$(OCExecutionAliasName).exe</TargetPath>
-      </_FilteredNonWapProjProjectOutput>
-    </ItemGroup>
+	<ItemGroup>
+	  <!-- Stomp all "SourceProject" values for all incoming dependencies to flatten the package. -->
+	  <_TemporaryFilteredWapProjOutput Include="@(_FilteredNonWapProjProjectOutput)" />
+	  <_FilteredNonWapProjProjectOutput Remove="@(_TemporaryFilteredWapProjOutput)" />
+	  <_FilteredNonWapProjProjectOutput Include="@(_TemporaryFilteredWapProjOutput)">
+		<!-- Blank the SourceProject here to vend all files into the root of the package. -->
+		<SourceProject>
+		</SourceProject>
+		<!-- Replace the filename for wt/wtd.exe with the one the manifest wants. -->
+		<TargetPath Condition="'%(Filename)' == 'wt' and '%(Extension)' == '.exe'">$(OCExecutionAliasName).exe</TargetPath>
+	  </_FilteredNonWapProjProjectOutput>
+	</ItemGroup>
   </Target>
   <!-- Move all the PRI files that would be packaged into the appx into _PriFile so that
-       GenerateProjectPriFile catches them. This requires us to move payload collection
-       up before GenerateProjectPriFile, when it is typically _after_ it (because the
-       DesktopBridge project type is built to only prepare the payload during appx manifest
-       generation.
+	   GenerateProjectPriFile catches them. This requires us to move payload collection
+	   up before GenerateProjectPriFile, when it is typically _after_ it (because the
+	   DesktopBridge project type is built to only prepare the payload during appx manifest
+	   generation.
 
-       Since PRI file generation is _before_ manifest generation (for possibly obvious or
-       important reasons), that doesn't work for us.
+	   Since PRI file generation is _before_ manifest generation (for possibly obvious or
+	   important reasons), that doesn't work for us.
   -->
   <Target Name="OpenConsoleLiftDesktopBridgePriFiles" DependsOnTargets="_ConvertItems">
-    <ItemGroup>
-      <_PriFile Include="@(_NonWapProjProjectOutput)" Condition="'%(Extension)' == '.pri'" />
-      <!-- Remove all other .pri files from the appx payload. -->
-      <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.pri'" />
-    </ItemGroup>
+	<ItemGroup>
+	  <_PriFile Include="@(_NonWapProjProjectOutput)" Condition="'%(Extension)' == '.pri'" />
+	  <!-- Remove all other .pri files from the appx payload. -->
+	  <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.pri'" />
+	</ItemGroup>
   </Target>
   <!-- VS 16.3.0 added a rule to the WAP packaging project that removes all non-WAP payload, which we were relying on to
-       roll up our subproject resources. We have to suppress that rule but keep part of its logic, because that rule is
-       where the AppxPackagePayload items are created. -->
+	   roll up our subproject resources. We have to suppress that rule but keep part of its logic, because that rule is
+	   where the AppxPackagePayload items are created. -->
   <PropertyGroup>
-    <WapProjBeforeGenerateAppxManifestDependsOn>
-        $([MSBuild]::Unescape('$(WapProjBeforeGenerateAppxManifestDependsOn.Replace('_RemoveAllNonWapUWPItems', '_OpenConsoleRemoveAllNonWapUWPItems'))'))
-    </WapProjBeforeGenerateAppxManifestDependsOn>
+	<WapProjBeforeGenerateAppxManifestDependsOn>
+		$([MSBuild]::Unescape('$(WapProjBeforeGenerateAppxManifestDependsOn.Replace('_RemoveAllNonWapUWPItems', '_OpenConsoleRemoveAllNonWapUWPItems'))'))
+	</WapProjBeforeGenerateAppxManifestDependsOn>
   </PropertyGroup>
   <Target Name="_OpenConsoleRemoveAllNonWapUWPItems">
-    <ItemGroup>
-      <AppxPackagePayload Include="@(WapProjPackageFile)" />
-      <AppxUploadPackagePayload Include="@(UploadWapProjPackageFile)" />
-      <!-- 16.3.0 - remove non-resources.pri PRI files since we just forced them back in. -->
-      <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.pri' and '%(Filename)' != 'resources'" />
-      <AppxUploadPackagePayload Remove="@(AppxUploadPackagePayload)" Condition="'%(Extension)' == '.pri' and '%(Filename)' != 'resources'" />
-
-      <!-- Remove all of the xaml files, because we are using embedded xbf payloads (saves about 500kb on disk!) -->
-      <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.xaml'" />
-      <AppxUploadPackagePayload Remove="@(AppxUploadPackagePayload)" Condition="'%(Extension)' == '.xaml'" />
-    </ItemGroup>
+	<ItemGroup>
+	  <AppxPackagePayload Include="@(WapProjPackageFile)" />
+	  <AppxUploadPackagePayload Include="@(UploadWapProjPackageFile)" />
+	  <!-- 16.3.0 - remove non-resources.pri PRI files since we just forced them back in. -->
+	  <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.pri' and '%(Filename)' != 'resources'" />
+	  <AppxUploadPackagePayload Remove="@(AppxUploadPackagePayload)" Condition="'%(Extension)' == '.pri' and '%(Filename)' != 'resources'" />
+	  <!-- Remove all of the xaml files, because we are using embedded xbf payloads (saves about 500kb on disk!) -->
+	  <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.xaml'" />
+	  <AppxUploadPackagePayload Remove="@(AppxUploadPackagePayload)" Condition="'%(Extension)' == '.xaml'" />
+	</ItemGroup>
   </Target>
-
   <!--
-    Some of our dependencies still require a CRT, so we're going to ship the forwarders in our package and
-    depend on the desktop CRT. This lets us unify the Windows 10 and Windows 11 builds around a common CRT.
+	Some of our dependencies still require a CRT, so we're going to ship the forwarders in our package and
+	depend on the desktop CRT. This lets us unify the Windows 10 and Windows 11 builds around a common CRT.
   -->
   <!-- This target removes the FrameworkSdkReferences from before the AppX package targets manifest generation happens.
-       This is part of the generic machinery that applies to every AppX. -->
+	   This is part of the generic machinery that applies to every AppX. -->
   <Target Name="_OpenConsoleStripAllDependenciesFromPackageFirstManifest" BeforeTargets="_GenerateCurrentProjectAppxManifest">
-    <ItemGroup>
-      <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs'" />
-      <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug'" />
-      <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs.Desktop'" />
-      <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.UWPDesktop' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug.UWPDesktop'" />
-    </ItemGroup>
+	<ItemGroup>
+	  <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs'" />
+	  <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug'" />
+	  <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs.Desktop'" />
+	  <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.UWPDesktop' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug.UWPDesktop'" />
+	</ItemGroup>
   </Target>
-
   <!-- This target removes the FrameworkSdkPackages from before the *desktop bridge* manifest generation happens. -->
   <Target Name="_OpenConsoleStripAllDependenciesFromPackageSecondManifest" BeforeTargets="_GenerateDesktopBridgeAppxManifest" DependsOnTargets="_ResolveVCLibDependencies">
-    <ItemGroup>
-      <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs'" />
-      <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug'" />
-      <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs.Desktop'" />
-      <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.UWPDesktop' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug.UWPDesktop'" />
-    </ItemGroup>
+	<ItemGroup>
+	  <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs'" />
+	  <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug'" />
+	  <FrameworkSdkReference Remove="@(FrameworkSdkReference)" Condition="'%(FrameworkSdkReference.SimpleName)'=='Microsoft.VCLibs.Desktop'" />
+	  <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" Condition="'%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.UWPDesktop' or '%(FrameworkSdkPackage.Name)'=='Microsoft.VCLibs.140.00.Debug.UWPDesktop'" />
+	</ItemGroup>
   </Target>
-
   <!-- This is required to get the package dependency in the AppXManifest. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
 </Project>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -18,7 +18,7 @@
 
   <Identity Name="WindowsTerminalDev"
     Publisher="CN=Dm17tryK"
-    Version="1.25.55109.11" />
+    Version="1.25.55109.12" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreNameDev</DisplayName>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -18,7 +18,7 @@
 
   <Identity Name="WindowsTerminalDev"
     Publisher="CN=Dm17tryK"
-    Version="1.25.55109.9" />
+    Version="1.25.55109.11" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreNameDev</DisplayName>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -18,7 +18,7 @@
 
   <Identity Name="WindowsTerminalDev"
     Publisher="CN=Dm17tryK"
-    Version="1.25.54109.9" />
+    Version="1.25.55109.9" />
 
   <Properties>
     <DisplayName>ms-resource:AppStoreNameDev</DisplayName>

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -8,159 +8,161 @@
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
 {
-    class CommandlineTest;
+	class CommandlineTest;
 };
 #endif
 
 namespace TerminalApp
 {
-    class AppCommandlineArgs;
+	class AppCommandlineArgs;
 };
 
 class TerminalApp::AppCommandlineArgs final
 {
 public:
-    static constexpr std::string_view NixHelpFlag{ "-?" };
-    static constexpr std::string_view WindowsHelpFlag{ "/?" };
-    static constexpr std::wstring_view PlaceholderExeName{ L"wt.exe" };
+	static constexpr std::string_view NixHelpFlag{ "-?" };
+	static constexpr std::string_view WindowsHelpFlag{ "/?" };
+	static constexpr std::wstring_view PlaceholderExeName{ L"wt.exe" };
 
-    AppCommandlineArgs();
-    ~AppCommandlineArgs() = default;
+	AppCommandlineArgs();
+	~AppCommandlineArgs() = default;
 
-    int ParseCommand(const Commandline& command);
-    int ParseArgs(winrt::array_view<const winrt::hstring> args);
+	int ParseCommand(const Commandline& command);
+	int ParseArgs(winrt::array_view<const winrt::hstring> args);
 
-    static std::vector<Commandline> BuildCommands(const std::vector<const wchar_t*>& args);
-    static std::vector<Commandline> BuildCommands(winrt::array_view<const winrt::hstring> args);
+	static std::vector<Commandline> BuildCommands(const std::vector<const wchar_t*>& args);
+	static std::vector<Commandline> BuildCommands(winrt::array_view<const winrt::hstring> args);
 
-    void ValidateStartupCommands();
-    std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& GetStartupActions();
-    bool IsHandoffListener() const noexcept;
-    const std::string& GetExitMessage() const noexcept;
-    bool ShouldExitEarly() const noexcept;
+	void ValidateStartupCommands();
+	std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& GetStartupActions();
+	bool IsHandoffListener() const noexcept;
+	const std::string& GetExitMessage() const noexcept;
+	bool ShouldExitEarly() const noexcept;
 
-    std::optional<uint32_t> GetPersistedLayoutIdx() const noexcept;
-    std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> GetLaunchMode() const noexcept;
-    std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> GetPosition() const noexcept;
-    std::optional<til::size> GetSize() const noexcept;
+	std::optional<uint32_t> GetPersistedLayoutIdx() const noexcept;
+	std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> GetLaunchMode() const noexcept;
+	std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> GetPosition() const noexcept;
+	std::optional<til::size> GetSize() const noexcept;
 
-    int ParseArgs(const winrt::Microsoft::Terminal::Settings::Model::ExecuteCommandlineArgs& args);
-    void DisableHelpInExitMessage();
-    void FullResetState();
+	int ParseArgs(const winrt::Microsoft::Terminal::Settings::Model::ExecuteCommandlineArgs& args);
+	void DisableHelpInExitMessage();
+	void FullResetState();
 
-    std::string_view GetTargetWindow() const noexcept;
-    std::string_view GetLocalState() const noexcept;
+	std::string_view GetTargetWindow() const noexcept;
+	std::string_view GetLocalState() const noexcept;
+	std::string_view GetProjectName() const noexcept;
 
 private:
-    static const std::wregex _commandDelimiterRegex;
+	static const std::wregex _commandDelimiterRegex;
 
-    CLI::App _app{ "wt - the Windows Terminal" };
+	CLI::App _app{ "wt - the Windows Terminal" };
 
-    // This is a helper struct to encapsulate all the options for a subcommand
-    // that produces a NewTerminalArgs.
-    struct NewTerminalSubcommand
-    {
-        CLI::App* subcommand;
-        CLI::Option* commandlineOption;
-        CLI::Option* profileNameOption;
-        CLI::Option* sessionIdOption;
-        CLI::Option* startingDirectoryOption;
-        CLI::Option* titleOption;
-        CLI::Option* tabColorOption;
-        CLI::Option* suppressApplicationTitleOption;
-        CLI::Option* colorSchemeOption;
-        CLI::Option* appendCommandLineOption;
-        CLI::Option* inheritEnvOption;
-    };
+	// This is a helper struct to encapsulate all the options for a subcommand
+	// that produces a NewTerminalArgs.
+	struct NewTerminalSubcommand
+	{
+		CLI::App* subcommand;
+		CLI::Option* commandlineOption;
+		CLI::Option* profileNameOption;
+		CLI::Option* sessionIdOption;
+		CLI::Option* startingDirectoryOption;
+		CLI::Option* titleOption;
+		CLI::Option* tabColorOption;
+		CLI::Option* suppressApplicationTitleOption;
+		CLI::Option* colorSchemeOption;
+		CLI::Option* appendCommandLineOption;
+		CLI::Option* inheritEnvOption;
+	};
 
-    struct NewPaneSubcommand : public NewTerminalSubcommand
-    {
-        CLI::Option* _horizontalOption;
-        CLI::Option* _verticalOption;
-        CLI::Option* _duplicateOption;
-    };
+	struct NewPaneSubcommand : public NewTerminalSubcommand
+	{
+		CLI::Option* _horizontalOption;
+		CLI::Option* _verticalOption;
+		CLI::Option* _duplicateOption;
+	};
 
-    // --- Subcommands ---
-    NewTerminalSubcommand _newTabCommand;
-    NewTerminalSubcommand _newTabShort;
-    NewPaneSubcommand _newPaneCommand;
-    NewPaneSubcommand _newPaneShort;
-    CLI::App* _focusTabCommand;
-    CLI::App* _focusTabShort;
-    CLI::App* _moveFocusCommand;
-    CLI::App* _moveFocusShort;
-    CLI::App* _movePaneCommand;
-    CLI::App* _movePaneShort;
-    CLI::App* _swapPaneCommand;
-    CLI::App* _focusPaneCommand;
-    CLI::App* _focusPaneShort;
-    CLI::App* _saveCommand;
+	// --- Subcommands ---
+	NewTerminalSubcommand _newTabCommand;
+	NewTerminalSubcommand _newTabShort;
+	NewPaneSubcommand _newPaneCommand;
+	NewPaneSubcommand _newPaneShort;
+	CLI::App* _focusTabCommand;
+	CLI::App* _focusTabShort;
+	CLI::App* _moveFocusCommand;
+	CLI::App* _moveFocusShort;
+	CLI::App* _movePaneCommand;
+	CLI::App* _movePaneShort;
+	CLI::App* _swapPaneCommand;
+	CLI::App* _focusPaneCommand;
+	CLI::App* _focusPaneShort;
+	CLI::App* _saveCommand;
 
-    // Are you adding a new sub-command? Make sure to update _noCommandsProvided!
+	// Are you adding a new sub-command? Make sure to update _noCommandsProvided!
 
-    std::string _profileName;
-    std::string _sessionId;
-    std::string _startingDirectory;
-    std::string _startingTitle;
-    std::string _startingTabColor;
-    std::string _startingColorScheme;
-    bool _suppressApplicationTitle{ false };
-    bool _inheritEnvironment{ false };
+	std::string _profileName;
+	std::string _sessionId;
+	std::string _startingDirectory;
+	std::string _startingTitle;
+	std::string _startingTabColor;
+	std::string _startingColorScheme;
+	bool _suppressApplicationTitle{ false };
+	bool _inheritEnvironment{ false };
 
-    winrt::Microsoft::Terminal::Settings::Model::FocusDirection _moveFocusDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };
-    winrt::Microsoft::Terminal::Settings::Model::FocusDirection _swapPaneDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };
+	winrt::Microsoft::Terminal::Settings::Model::FocusDirection _moveFocusDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };
+	winrt::Microsoft::Terminal::Settings::Model::FocusDirection _swapPaneDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };
 
-    // _commandline will contain the command line with which we'll be spawning a new terminal
-    std::vector<std::string> _commandline;
-    bool _appendCommandLineOption{ false };
+	// _commandline will contain the command line with which we'll be spawning a new terminal
+	std::vector<std::string> _commandline;
+	bool _appendCommandLineOption{ false };
 
-    bool _splitVertical{ false };
-    bool _splitHorizontal{ false };
-    bool _splitDuplicate{ false };
-    float _splitPaneSize{ 0.5f };
+	bool _splitVertical{ false };
+	bool _splitHorizontal{ false };
+	bool _splitDuplicate{ false };
+	float _splitPaneSize{ 0.5f };
 
-    int _movePaneTabIndex{ -1 };
-    int _focusTabIndex{ -1 };
-    bool _focusNextTab{ false };
-    bool _focusPrevTab{ false };
+	int _movePaneTabIndex{ -1 };
+	int _focusTabIndex{ -1 };
+	bool _focusNextTab{ false };
+	bool _focusPrevTab{ false };
 
-    int _focusPaneTarget{ -1 };
-    std::string _saveInputName;
-    std::string _keyChordOption;
-    // Are you adding more args here? Make sure to reset them in _resetStateToDefault
+	int _focusPaneTarget{ -1 };
+	std::string _saveInputName;
+	std::string _keyChordOption;
+	// Are you adding more args here? Make sure to reset them in _resetStateToDefault
 
-    const Commandline* _currentCommandline{ nullptr };
-    std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> _launchMode{ std::nullopt };
-    std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> _position{ std::nullopt };
-    std::optional<til::size> _size{ std::nullopt };
-    bool _isHandoffListener{ false };
-    std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs> _startupActions;
-    std::string _exitMessage;
-    bool _shouldExitEarly{ false };
+	const Commandline* _currentCommandline{ nullptr };
+	std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> _launchMode{ std::nullopt };
+	std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> _position{ std::nullopt };
+	std::optional<til::size> _size{ std::nullopt };
+	bool _isHandoffListener{ false };
+	std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs> _startupActions;
+	std::string _exitMessage;
+	bool _shouldExitEarly{ false };
 
-    int _loadPersistedLayoutIdx{};
-    std::string _windowTarget{};
-    std::string _localState{};
-    // Are you adding more args or attributes here? If they are not reset in _resetStateToDefault, make sure to reset them in FullResetState
+	int _loadPersistedLayoutIdx{};
+	std::string _windowTarget{};
+	std::string _localState{};
+	std::string _projectName{};
+	// Are you adding more args or attributes here? If they are not reset in _resetStateToDefault, make sure to reset them in FullResetState
 
-    winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs _getNewTerminalArgs(NewTerminalSubcommand& subcommand);
-    void _addNewTerminalArgs(NewTerminalSubcommand& subcommand);
-    void _buildParser();
-    void _buildSaveSnippetParser();
-    void _buildNewTabParser();
-    void _buildSplitPaneParser();
-    void _buildFocusTabParser();
-    void _buildMoveFocusParser();
-    void _buildMovePaneParser();
-    void _buildSwapPaneParser();
-    void _buildFocusPaneParser();
-    bool _noCommandsProvided();
-    void _resetStateToDefault();
-    int _handleExit(const CLI::App& command, const CLI::Error& e);
+	winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs _getNewTerminalArgs(NewTerminalSubcommand& subcommand);
+	void _addNewTerminalArgs(NewTerminalSubcommand& subcommand);
+	void _buildParser();
+	void _buildSaveSnippetParser();
+	void _buildNewTabParser();
+	void _buildSplitPaneParser();
+	void _buildFocusTabParser();
+	void _buildMoveFocusParser();
+	void _buildMovePaneParser();
+	void _buildSwapPaneParser();
+	void _buildFocusPaneParser();
+	bool _noCommandsProvided();
+	void _resetStateToDefault();
+	int _handleExit(const CLI::App& command, const CLI::Error& e);
 
-    static void _addCommandsForArg(std::vector<Commandline>& commands, std::wstring_view arg);
+	static void _addCommandsForArg(std::vector<Commandline>& commands, std::wstring_view arg);
 
 #ifdef UNIT_TESTING
-    friend class TerminalAppLocalTests::CommandlineTest;
+	friend class TerminalAppLocalTests::CommandlineTest;
 #endif
 };

--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -15,56 +15,61 @@ using namespace winrt::Windows::Foundation;
 
 namespace winrt::TerminalApp::implementation
 {
-    CommandlineArgs::CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString) :
-        _args{ args.begin(), args.end() },
-        CurrentDirectory{ std::move(currentDirectory) },
-        ShowWindowCommand{ showWindowCommand },
-        CurrentEnvironment{ std::move(envString) }
-    {
-        _parseResult = _parsed.ParseArgs(_args);
-        if (_parseResult == 0)
-        {
-            _parsed.ValidateStartupCommands();
-        }
-    }
+	CommandlineArgs::CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString) :
+		_args{ args.begin(), args.end() },
+		CurrentDirectory{ std::move(currentDirectory) },
+		ShowWindowCommand{ showWindowCommand },
+		CurrentEnvironment{ std::move(envString) }
+	{
+		_parseResult = _parsed.ParseArgs(_args);
+		if (_parseResult == 0)
+		{
+			_parsed.ValidateStartupCommands();
+		}
+	}
 
-    ::TerminalApp::AppCommandlineArgs& CommandlineArgs::ParsedArgs() noexcept
-    {
-        return _parsed;
-    }
+	::TerminalApp::AppCommandlineArgs& CommandlineArgs::ParsedArgs() noexcept
+	{
+		return _parsed;
+	}
 
-    winrt::com_array<winrt::hstring>& CommandlineArgs::CommandlineRef() noexcept
-    {
-        return _args;
-    }
+	winrt::com_array<winrt::hstring>& CommandlineArgs::CommandlineRef() noexcept
+	{
+		return _args;
+	}
 
-    int32_t CommandlineArgs::ExitCode() const noexcept
-    {
-        return _parseResult;
-    }
+	int32_t CommandlineArgs::ExitCode() const noexcept
+	{
+		return _parseResult;
+	}
 
-    winrt::hstring CommandlineArgs::ExitMessage() const
-    {
-        return winrt::to_hstring(_parsed.GetExitMessage());
-    }
+	winrt::hstring CommandlineArgs::ExitMessage() const
+	{
+		return winrt::to_hstring(_parsed.GetExitMessage());
+	}
 
-    winrt::hstring CommandlineArgs::TargetWindow() const
-    {
-        return winrt::to_hstring(_parsed.GetTargetWindow());
-    }
+	winrt::hstring CommandlineArgs::TargetWindow() const
+	{
+		return winrt::to_hstring(_parsed.GetTargetWindow());
+	}
 
-    winrt::hstring CommandlineArgs::LocalState() const
-    {
-        return winrt::to_hstring(_parsed.GetLocalState());
-    }
+	winrt::hstring CommandlineArgs::LocalState() const
+	{
+		return winrt::to_hstring(_parsed.GetLocalState());
+	}
 
-    void CommandlineArgs::Commandline(const winrt::array_view<const winrt::hstring>& value)
-    {
-        _args = { value.begin(), value.end() };
-    }
+	winrt::hstring CommandlineArgs::ProjectName() const
+	{
+		return winrt::to_hstring(_parsed.GetProjectName());
+	}
 
-    winrt::com_array<winrt::hstring> CommandlineArgs::Commandline()
-    {
-        return winrt::com_array<winrt::hstring>{ _args.begin(), _args.end() };
-    }
+	void CommandlineArgs::Commandline(const winrt::array_view<const winrt::hstring>& value)
+	{
+		_args = { value.begin(), value.end() };
+	}
+
+	winrt::com_array<winrt::hstring> CommandlineArgs::Commandline()
+	{
+		return winrt::com_array<winrt::hstring>{ _args.begin(), _args.end() };
+	}
 }

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -11,94 +11,95 @@
 
 namespace winrt::TerminalApp::implementation
 {
-    struct CommandlineArgs : public CommandlineArgsT<CommandlineArgs>
-    {
-        CommandlineArgs() = default;
-        CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString);
+	struct CommandlineArgs : public CommandlineArgsT<CommandlineArgs>
+	{
+		CommandlineArgs() = default;
+		CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString);
 
-        ::TerminalApp::AppCommandlineArgs& ParsedArgs() noexcept;
-        winrt::com_array<winrt::hstring>& CommandlineRef() noexcept;
+		::TerminalApp::AppCommandlineArgs& ParsedArgs() noexcept;
+		winrt::com_array<winrt::hstring>& CommandlineRef() noexcept;
 
-        // These bits are exposed via WinRT:
-    public:
-        int32_t ExitCode() const noexcept;
-        winrt::hstring ExitMessage() const;
-        winrt::hstring TargetWindow() const;
-        winrt::hstring LocalState() const;
+		// These bits are exposed via WinRT:
+	public:
+		int32_t ExitCode() const noexcept;
+		winrt::hstring ExitMessage() const;
+		winrt::hstring TargetWindow() const;
+		winrt::hstring LocalState() const;
+		winrt::hstring ProjectName() const;
 
-        void Commandline(const winrt::array_view<const winrt::hstring>& value);
-        winrt::com_array<winrt::hstring> Commandline();
+		void Commandline(const winrt::array_view<const winrt::hstring>& value);
+		winrt::com_array<winrt::hstring> Commandline();
 
-        til::property<winrt::hstring> CurrentDirectory;
-        til::property<winrt::hstring> CurrentEnvironment;
-        til::property<uint32_t> ShowWindowCommand{ static_cast<uint32_t>(SW_NORMAL) }; // SW_NORMAL is 1, 0 is SW_HIDE
+		til::property<winrt::hstring> CurrentDirectory;
+		til::property<winrt::hstring> CurrentEnvironment;
+		til::property<uint32_t> ShowWindowCommand{ static_cast<uint32_t>(SW_NORMAL) }; // SW_NORMAL is 1, 0 is SW_HIDE
 
-    private:
-        ::TerminalApp::AppCommandlineArgs _parsed;
-        int32_t _parseResult = 0;
-        winrt::com_array<winrt::hstring> _args;
-    };
+	private:
+		::TerminalApp::AppCommandlineArgs _parsed;
+		int32_t _parseResult = 0;
+		winrt::com_array<winrt::hstring> _args;
+	};
 
-    struct RequestReceiveContentArgs : RequestReceiveContentArgsT<RequestReceiveContentArgs>
-    {
-        WINRT_PROPERTY(uint64_t, SourceWindow);
-        WINRT_PROPERTY(uint64_t, TargetWindow);
-        WINRT_PROPERTY(uint32_t, TabIndex);
+	struct RequestReceiveContentArgs : RequestReceiveContentArgsT<RequestReceiveContentArgs>
+	{
+		WINRT_PROPERTY(uint64_t, SourceWindow);
+		WINRT_PROPERTY(uint64_t, TargetWindow);
+		WINRT_PROPERTY(uint32_t, TabIndex);
 
-    public:
-        RequestReceiveContentArgs(const uint64_t src, const uint64_t tgt, const uint32_t tabIndex) :
-            _SourceWindow{ src },
-            _TargetWindow{ tgt },
-            _TabIndex{ tabIndex } {};
-    };
+	public:
+		RequestReceiveContentArgs(const uint64_t src, const uint64_t tgt, const uint32_t tabIndex) :
+			_SourceWindow{ src },
+			_TargetWindow{ tgt },
+			_TabIndex{ tabIndex } {};
+	};
 
-    struct SummonWindowBehavior : public SummonWindowBehaviorT<SummonWindowBehavior>
-    {
-    public:
-        SummonWindowBehavior() = default;
-        WINRT_PROPERTY(bool, MoveToCurrentDesktop, true);
-        WINRT_PROPERTY(bool, ToggleVisibility, true);
-        WINRT_PROPERTY(uint32_t, DropdownDuration, 0);
-        WINRT_PROPERTY(MonitorBehavior, ToMonitor, MonitorBehavior::ToCurrent);
+	struct SummonWindowBehavior : public SummonWindowBehaviorT<SummonWindowBehavior>
+	{
+	public:
+		SummonWindowBehavior() = default;
+		WINRT_PROPERTY(bool, MoveToCurrentDesktop, true);
+		WINRT_PROPERTY(bool, ToggleVisibility, true);
+		WINRT_PROPERTY(uint32_t, DropdownDuration, 0);
+		WINRT_PROPERTY(MonitorBehavior, ToMonitor, MonitorBehavior::ToCurrent);
 
-    public:
-        SummonWindowBehavior(const SummonWindowBehavior& other) :
-            _MoveToCurrentDesktop{ other.MoveToCurrentDesktop() },
-            _ToMonitor{ other.ToMonitor() },
-            _DropdownDuration{ other.DropdownDuration() },
-            _ToggleVisibility{ other.ToggleVisibility() } {};
-    };
+	public:
+		SummonWindowBehavior(const SummonWindowBehavior& other) :
+			_MoveToCurrentDesktop{ other.MoveToCurrentDesktop() },
+			_ToMonitor{ other.ToMonitor() },
+			_DropdownDuration{ other.DropdownDuration() },
+			_ToggleVisibility{ other.ToggleVisibility() } {};
+	};
 
-    struct WindowRequestedArgs : public WindowRequestedArgsT<WindowRequestedArgs>
-    {
-    public:
-        WindowRequestedArgs(uint64_t id, const winrt::TerminalApp::CommandlineArgs& command) :
-            _Id{ id },
-            _Command{ std::move(command) }
-        {
-        }
+	struct WindowRequestedArgs : public WindowRequestedArgsT<WindowRequestedArgs>
+	{
+	public:
+		WindowRequestedArgs(uint64_t id, const winrt::TerminalApp::CommandlineArgs& command) :
+			_Id{ id },
+			_Command{ std::move(command) }
+		{
+		}
 
-        WindowRequestedArgs(const winrt::hstring& window, const winrt::hstring& content, const Windows::Foundation::IReference<Windows::Foundation::Rect>& bounds) :
-            _WindowName{ window },
-            _Content{ content },
-            _InitialBounds{ bounds }
-        {
-        }
+		WindowRequestedArgs(const winrt::hstring& window, const winrt::hstring& content, const Windows::Foundation::IReference<Windows::Foundation::Rect>& bounds) :
+			_WindowName{ window },
+			_Content{ content },
+			_InitialBounds{ bounds }
+		{
+		}
 
-        WINRT_PROPERTY(uint64_t, Id);
-        WINRT_PROPERTY(winrt::hstring, WindowName);
-        WINRT_PROPERTY(TerminalApp::CommandlineArgs, Command);
-        WINRT_PROPERTY(winrt::hstring, Content);
-        WINRT_PROPERTY(Windows::Foundation::IReference<Windows::Foundation::Rect>, InitialBounds);
+		WINRT_PROPERTY(uint64_t, Id);
+		WINRT_PROPERTY(winrt::hstring, WindowName);
+		WINRT_PROPERTY(TerminalApp::CommandlineArgs, Command);
+		WINRT_PROPERTY(winrt::hstring, Content);
+		WINRT_PROPERTY(Windows::Foundation::IReference<Windows::Foundation::Rect>, InitialBounds);
 
-    private:
-    };
+	private:
+	};
 }
 
 namespace winrt::TerminalApp::factory_implementation
 {
-    BASIC_FACTORY(SummonWindowBehavior);
-    BASIC_FACTORY(CommandlineArgs);
-    BASIC_FACTORY(RequestReceiveContentArgs);
-    BASIC_FACTORY(WindowRequestedArgs);
+	BASIC_FACTORY(SummonWindowBehavior);
+	BASIC_FACTORY(CommandlineArgs);
+	BASIC_FACTORY(RequestReceiveContentArgs);
+	BASIC_FACTORY(WindowRequestedArgs);
 }

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -3,54 +3,55 @@
 
 namespace TerminalApp
 {
-    runtimeclass CommandlineArgs
-    {
-        CommandlineArgs();
-        CommandlineArgs(String[] args, String cwd, UInt32 showWindowCommand, String env);
+	runtimeclass CommandlineArgs
+	{
+		CommandlineArgs();
+		CommandlineArgs(String[] args, String cwd, UInt32 showWindowCommand, String env);
 
-        Int32 ExitCode { get; };
-        String ExitMessage { get; };
-        String TargetWindow { get; };
-        String LocalState { get; };
+		Int32 ExitCode { get; };
+		String ExitMessage { get; };
+		String TargetWindow { get; };
+		String LocalState { get; };
+		String ProjectName { get; };
 
-        String[] Commandline;
-        String CurrentDirectory { get; };
-        UInt32 ShowWindowCommand { get; };
-        String CurrentEnvironment { get; };
-    };
+		String[] Commandline;
+		String CurrentDirectory { get; };
+		UInt32 ShowWindowCommand { get; };
+		String CurrentEnvironment { get; };
+	};
 
-    enum MonitorBehavior
-    {
-        InPlace,
-        ToCurrent,
-        ToMouse,
-    };
+	enum MonitorBehavior
+	{
+		InPlace,
+		ToCurrent,
+		ToMouse,
+	};
 
-    [default_interface] runtimeclass SummonWindowBehavior {
-        SummonWindowBehavior();
-        Boolean MoveToCurrentDesktop;
-        Boolean ToggleVisibility;
-        UInt32 DropdownDuration;
-        MonitorBehavior ToMonitor;
-    }
+	[default_interface] runtimeclass SummonWindowBehavior {
+		SummonWindowBehavior();
+		Boolean MoveToCurrentDesktop;
+		Boolean ToggleVisibility;
+		UInt32 DropdownDuration;
+		MonitorBehavior ToMonitor;
+	}
 
-    [default_interface] runtimeclass RequestReceiveContentArgs {
-        RequestReceiveContentArgs(UInt64 src, UInt64 tgt, UInt32 tabIndex);
+	[default_interface] runtimeclass RequestReceiveContentArgs {
+		RequestReceiveContentArgs(UInt64 src, UInt64 tgt, UInt32 tabIndex);
 
-        UInt64 SourceWindow { get; };
-        UInt64 TargetWindow { get; };
-        UInt32 TabIndex { get; };
-    };
+		UInt64 SourceWindow { get; };
+		UInt64 TargetWindow { get; };
+		UInt32 TabIndex { get; };
+	};
 
-    [default_interface] runtimeclass WindowRequestedArgs {
-        WindowRequestedArgs(UInt64 id, CommandlineArgs command);
-        WindowRequestedArgs(String window, String content, Windows.Foundation.IReference<Windows.Foundation.Rect> bounds);
+	[default_interface] runtimeclass WindowRequestedArgs {
+		WindowRequestedArgs(UInt64 id, CommandlineArgs command);
+		WindowRequestedArgs(String window, String content, Windows.Foundation.IReference<Windows.Foundation.Rect> bounds);
 
-        UInt64 Id;
-        String WindowName;
+		UInt64 Id;
+		String WindowName;
 
-        CommandlineArgs Command { get; };
-        String Content { get; };
-        Windows.Foundation.IReference<Windows.Foundation.Rect> InitialBounds { get; };
-    };
+		CommandlineArgs Command { get; };
+		String Content { get; };
+		Windows.Foundation.IReference<Windows.Foundation.Rect> InitialBounds { get; };
+	};
 }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -466,6 +466,9 @@
   </data>
   <data name="CmdLocalStateArgDesc" xml:space="preserve">
     <value>Local State folder path.</value>
+  </data>
+  <data name="CmdProjectArgDesc" xml:space="preserve">
+    <value>Project Name (will save separate layout and settings).</value>
   </data>
   <data name="CmdWindowTargetArgDesc" xml:space="preserve">
     <value>Specify a terminal window to run the given commandline in. "0" always refers to the current window. </value>

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -80,6 +80,9 @@
     <ClInclude Include="NewTabMenu.h">
       <DependentUpon>NewTabMenu.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="NewProjectMenu.h">
+      <DependentUpon>NewProjectMenu.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="pch.h" />
     <ClInclude Include="MainPage.h">
       <DependentUpon>MainPage.xaml</DependentUpon>
@@ -123,6 +126,10 @@
     </ClInclude>
     <ClInclude Include="NewTabMenuViewModel.h">
       <DependentUpon>NewTabMenuViewModel.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="NewProjectMenuViewModel.h">
+      <DependentUpon>NewProjectMenuViewModel.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
     <ClInclude Include="Extensions.h">
@@ -200,6 +207,9 @@
     <Page Include="NewTabMenu.xaml">
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="NewProjectMenu.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="MainPage.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -269,6 +279,9 @@
     <ClCompile Include="NewTabMenu.cpp">
       <DependentUpon>NewTabMenu.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="NewProjectMenu.cpp">
+      <DependentUpon>NewProjectMenu.xaml</DependentUpon>
+    </ClCompile>
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -314,6 +327,10 @@
     </ClCompile>
     <ClCompile Include="NewTabMenuViewModel.cpp">
       <DependentUpon>NewTabMenuViewModel.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="NewProjectMenuViewModel.cpp">
+      <DependentUpon>NewProjectMenuViewModel.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
     <ClCompile Include="Extensions.cpp">
@@ -394,6 +411,10 @@
       <DependentUpon>NewTabMenu.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="NewProjectMenu.idl">
+      <DependentUpon>NewProjectMenu.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
     <Midl Include="Interaction.idl">
       <DependentUpon>Interaction.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -419,6 +440,7 @@
     <Midl Include="GlobalAppearanceViewModel.idl" />
     <Midl Include="LaunchViewModel.idl" />
     <Midl Include="NewTabMenuViewModel.idl" />
+    <Midl Include="NewProjectMenuViewModel.idl" />
     <Midl Include="Extensions.idl">
       <DependentUpon>Extensions.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
@@ -2,7 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Resources\en-US\Resources.resw" />
@@ -31,6 +30,7 @@
     <Midl Include="SettingContainer.idl" />
     <Midl Include="TerminalColorConverters.idl" />
     <Midl Include="NewTabMenuViewModel.idl" />
+    <Midl Include="NewProjectMenuViewModel.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(ProjectName).def" />
@@ -54,5 +54,10 @@
     <Page Include="KeyChordListener.xaml" />
     <Page Include="NullableColorPicker.xaml" />
     <Page Include="NewTabMenu.xaml" />
+    <Page Include="Compatibility.xaml" />
+    <Page Include="NewProjectMenu.xaml" />
+    <Page Include="Extensions.xaml" />
+    <Page Include="Profiles_Base_Orphaned.xaml" />
+    <Page Include="Profiles_Terminal.xaml" />
   </ItemGroup>
 </Project>

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenu.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenu.cpp
@@ -27,8 +27,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         //   to the view model, we'll just do this instead (much simpler).
         NewProjectMenuListView().SelectionChanged([this](auto&&, auto&&) {
             const auto list = NewProjectMenuListView();
-            MoveToFolderButton().IsEnabled(list.SelectedItems().Size() > 0);
-            DeleteMultipleButton().IsEnabled(list.SelectedItems().Size() > 0);
+            ProjectMoveToFolderButton().IsEnabled(list.SelectedItems().Size() > 0);
+            ProjectDeleteMultipleButton().IsEnabled(list.SelectedItems().Size() > 0);
         });
 
         Automation::AutomationProperties::SetName(ProjectMoveToFolderButton(), RS_(L"NewProjectMenu_MoveToFolderTextBlock/Text"));
@@ -48,12 +48,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void NewProjectMenu::ProjectFolderPickerDialog_Opened(const IInspectable& /*sender*/, const Controls::ContentDialogOpenedEventArgs& /*e*/)
     {
-        // Ideally, we'd bind IsPrimaryButtonEnabled to something like mtu:Converters.isEmpty(FolderTree.SelectedItems.Size) in the XAML.
-        // Similar to above, the XAML compiler can't find FolderTree when we try that.
+        // Ideally, we'd bind IsPrimaryButtonEnabled to something like mtu:Converters.isEmpty(ProjectFolderTree.SelectedItems.Size) in the XAML.
+        // Similar to above, the XAML compiler can't find ProjectFolderTree when we try that.
         // To make matters worse, SelectionChanged doesn't exist for WinUI 2's TreeView.
         // Let's just select the first item and call it a day.
         _ViewModel.GenerateFolderTree();
-        _ViewModel.CurrentProjectFolderTreeViewSelectedItem(_ViewModel.FolderTree().First().Current());
+        _ViewModel.CurrentProjectFolderTreeViewSelectedItem(_ViewModel.ProjectFolderTree().First().Current());
     }
 
     void NewProjectMenu::ProjectFolderPickerDialog_PrimaryButtonClick(const IInspectable& /*sender*/, const Controls::ContentDialogButtonClickEventArgs& /*e*/)
@@ -66,13 +66,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         // now actually move them
-        _ViewModel.RequestMoveEntriesToFolder(single_threaded_vector<Editor::NewProjectMenuEntryViewModel>(std::move(entries)), ProjectFolderTreeView().SelectedItem().as<Editor::FolderTreeViewEntry>().FolderEntryVM());
+        _ViewModel.RequestMoveEntriesToFolder(single_threaded_vector<Editor::NewProjectMenuEntryViewModel>(std::move(entries)), ProjectFolderTreeView().SelectedItem().as<Editor::ProjectFolderTreeViewEntry>().FolderEntryVM());
     }
 
     void NewProjectMenu::ProjectEditEntry_Clicked(const IInspectable& sender, const RoutedEventArgs& /*e*/)
     {
         const auto folderVM = sender.as<FrameworkElement>().DataContext().as<Editor::ProjectFolderEntryViewModel>();
-        _ViewModel.CurrentFolder(folderVM);
+        _ViewModel.CurrentProjectFolder(folderVM);
     }
 
     void NewProjectMenu::ProjectReorderEntry_Clicked(const IInspectable& sender, const RoutedEventArgs& /*e*/)
@@ -116,24 +116,24 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _ScrollToEntry(_ViewModel.RequestAddSelectedProjectEntry());
     }
 
-    void NewProjectMenu::AddSeparatorButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    void NewProjectMenu::AddProjectSeparatorButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
-        _ScrollToEntry(_ViewModel.RequestAddSeparatorEntry());
+        _ScrollToEntry(_ViewModel.RequestAddProjectSeparatorEntry());
     }
 
-    void NewProjectMenu::AddFolderButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    void NewProjectMenu::AddProjectFolderButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
-        _ScrollToEntry(_ViewModel.RequestAddFolderEntry());
+        _ScrollToEntry(_ViewModel.RequestAddProjectFolderEntry());
     }
 
-    void NewProjectMenu::AddMatchProjectsButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    void NewProjectMenu::AddProjectMatchButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
         _ScrollToEntry(_ViewModel.RequestAddProjectMatcherEntry());
     }
 
-    void NewProjectMenu::AddRemainingProjectsButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    void NewProjectMenu::AddProjectRemainingButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
-        _ScrollToEntry(_ViewModel.RequestAddRemainingProjectsEntry());
+        _ScrollToEntry(_ViewModel.RequestAddProjectRemainingEntry());
     }
 
     // As a QOL improvement, we scroll to the newly added entry.
@@ -146,15 +146,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         listView.ScrollIntoView(entry);
     }
 
-    void NewProjectMenu::AddFolderNameTextBox_KeyDown(const IInspectable& /*sender*/, const Input::KeyRoutedEventArgs& e)
+    void NewProjectMenu::AddProjectFolderNameTextBox_KeyDown(const IInspectable& /*sender*/, const Input::KeyRoutedEventArgs& e)
     {
         if (e.Key() == Windows::System::VirtualKey::Enter)
         {
             // We need to manually set the FolderName here because the TextBox's TextChanged event hasn't fired yet.
-            if (const auto folderName = FolderNameTextBox().Text(); !folderName.empty())
+            if (const auto folderName = ProjectFolderNameTextBox().Text(); !folderName.empty())
             {
-                _ViewModel.AddFolderName(folderName);
-                const auto entry = _ViewModel.RequestAddFolderEntry();
+                _ViewModel.AddProjectFolderName(folderName);
+                const auto entry = _ViewModel.RequestAddProjectFolderEntry();
                 NewProjectMenuListView().ScrollIntoView(entry);
             }
         }

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenu.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenu.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "NewProjectMenu.h"
+#include "NewProjectMenu.g.cpp"
+#include "NewProjectMenuEntryTemplateSelector.g.cpp"
+#include "EnumEntry.h"
+
+#include "NewProjectMenuViewModel.h"
+
+#include <LibraryResources.h>
+
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Navigation;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    NewProjectMenu::NewProjectMenu()
+    {
+        InitializeComponent();
+
+        // Ideally, we'd bind IsEnabled to something like mtu:Converters.isEmpty(NewProjectMenuListView.SelectedItems.Size) in the XAML,
+        //   but the XAML compiler can't find NewProjectMenuListView when we try that. Rather than copying the list of selected items over
+        //   to the view model, we'll just do this instead (much simpler).
+        NewProjectMenuListView().SelectionChanged([this](auto&&, auto&&) {
+            const auto list = NewProjectMenuListView();
+            MoveToFolderButton().IsEnabled(list.SelectedItems().Size() > 0);
+            DeleteMultipleButton().IsEnabled(list.SelectedItems().Size() > 0);
+        });
+
+        Automation::AutomationProperties::SetName(ProjectMoveToFolderButton(), RS_(L"NewProjectMenu_MoveToFolderTextBlock/Text"));
+        Automation::AutomationProperties::SetName(ProjectDeleteMultipleButton(), RS_(L"NewProjectMenu_DeleteMultipleTextBlock/Text"));
+        Automation::AutomationProperties::SetName(AddProjectComboBox(), RS_(L"NewProjectMenu_AddProject/Header"));
+        Automation::AutomationProperties::SetName(AddProjectButton(), RS_(L"NewProjectMenu_AddProjectButton/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(AddProjectSeparatorButton(), RS_(L"NewProjectMenu_AddSeparatorButton/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(AddProjectFolderButton(), RS_(L"NewProjectMenu_AddFolderButton/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(AddProjectMatchButton(), RS_(L"NewProjectMenu_AddProjectMatchTextBlock/Text"));
+        Automation::AutomationProperties::SetName(AddProjectRemainingButton(), RS_(L"NewProjectMenu_AddProjectRemainingButton/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+    }
+
+    void NewProjectMenu::OnNavigatedTo(const NavigationEventArgs& e)
+    {
+        _ViewModel = e.Parameter().as<Editor::NewProjectMenuViewModel>();
+    }
+
+    void NewProjectMenu::ProjectFolderPickerDialog_Opened(const IInspectable& /*sender*/, const Controls::ContentDialogOpenedEventArgs& /*e*/)
+    {
+        // Ideally, we'd bind IsPrimaryButtonEnabled to something like mtu:Converters.isEmpty(FolderTree.SelectedItems.Size) in the XAML.
+        // Similar to above, the XAML compiler can't find FolderTree when we try that.
+        // To make matters worse, SelectionChanged doesn't exist for WinUI 2's TreeView.
+        // Let's just select the first item and call it a day.
+        _ViewModel.GenerateFolderTree();
+        _ViewModel.CurrentProjectFolderTreeViewSelectedItem(_ViewModel.FolderTree().First().Current());
+    }
+
+    void NewProjectMenu::ProjectFolderPickerDialog_PrimaryButtonClick(const IInspectable& /*sender*/, const Controls::ContentDialogButtonClickEventArgs& /*e*/)
+    {
+        // copy selected items first (it updates as we move entries)
+        std::vector<Editor::NewProjectMenuEntryViewModel> entries;
+        for (const auto& item : NewProjectMenuListView().SelectedItems())
+        {
+            entries.push_back(item.as<Editor::NewProjectMenuEntryViewModel>());
+        }
+
+        // now actually move them
+        _ViewModel.RequestMoveEntriesToFolder(single_threaded_vector<Editor::NewProjectMenuEntryViewModel>(std::move(entries)), ProjectFolderTreeView().SelectedItem().as<Editor::FolderTreeViewEntry>().FolderEntryVM());
+    }
+
+    void NewProjectMenu::ProjectEditEntry_Clicked(const IInspectable& sender, const RoutedEventArgs& /*e*/)
+    {
+        const auto folderVM = sender.as<FrameworkElement>().DataContext().as<Editor::ProjectFolderEntryViewModel>();
+        _ViewModel.CurrentFolder(folderVM);
+    }
+
+    void NewProjectMenu::ProjectReorderEntry_Clicked(const IInspectable& sender, const RoutedEventArgs& /*e*/)
+    {
+        const auto btn = sender.as<Controls::Button>();
+        const auto entry = btn.DataContext().as<Editor::NewProjectMenuEntryViewModel>();
+        const auto direction = unbox_value<hstring>(btn.Tag());
+
+        _ViewModel.RequestReorderEntry(entry, direction == L"Up");
+    }
+
+    void NewProjectMenu::ProjectDeleteEntry_Clicked(const IInspectable& sender, const RoutedEventArgs& /*e*/)
+    {
+        const auto entry = sender.as<Controls::Button>().DataContext().as<Editor::NewProjectMenuEntryViewModel>();
+        _ViewModel.RequestDeleteEntry(entry);
+    }
+
+    safe_void_coroutine NewProjectMenu::ProjectMoveMultiple_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        co_await FindName(L"FolderPickerDialog").as<Controls::ContentDialog>().ShowAsync();
+    }
+
+    void NewProjectMenu::ProjectDeleteMultiple_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        // copy selected items first (it updates as we delete entries)
+        std::vector<Editor::NewProjectMenuEntryViewModel> entries;
+        for (const auto& item : NewProjectMenuListView().SelectedItems())
+        {
+            entries.push_back(item.as<Editor::NewProjectMenuEntryViewModel>());
+        }
+
+        // now actually delete them
+        for (const auto& vm : entries)
+        {
+            _ViewModel.RequestDeleteEntry(vm);
+        }
+    }
+
+    void NewProjectMenu::AddProjectButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        _ScrollToEntry(_ViewModel.RequestAddSelectedProjectEntry());
+    }
+
+    void NewProjectMenu::AddSeparatorButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        _ScrollToEntry(_ViewModel.RequestAddSeparatorEntry());
+    }
+
+    void NewProjectMenu::AddFolderButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        _ScrollToEntry(_ViewModel.RequestAddFolderEntry());
+    }
+
+    void NewProjectMenu::AddMatchProjectsButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        _ScrollToEntry(_ViewModel.RequestAddProjectMatcherEntry());
+    }
+
+    void NewProjectMenu::AddRemainingProjectsButton_Clicked(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        _ScrollToEntry(_ViewModel.RequestAddRemainingProjectsEntry());
+    }
+
+    // As a QOL improvement, we scroll to the newly added entry.
+    // Calling ScrollIntoView() on its own causes the items to briefly disappear.
+    // Calling UpdateLayout() beforehand remedies this issue.
+    void NewProjectMenu::_ScrollToEntry(const Editor::NewProjectMenuEntryViewModel& entry)
+    {
+        const auto& listView = NewProjectMenuListView();
+        listView.UpdateLayout();
+        listView.ScrollIntoView(entry);
+    }
+
+    void NewProjectMenu::AddFolderNameTextBox_KeyDown(const IInspectable& /*sender*/, const Input::KeyRoutedEventArgs& e)
+    {
+        if (e.Key() == Windows::System::VirtualKey::Enter)
+        {
+            // We need to manually set the FolderName here because the TextBox's TextChanged event hasn't fired yet.
+            if (const auto folderName = FolderNameTextBox().Text(); !folderName.empty())
+            {
+                _ViewModel.AddFolderName(folderName);
+                const auto entry = _ViewModel.RequestAddFolderEntry();
+                NewProjectMenuListView().ScrollIntoView(entry);
+            }
+        }
+    }
+
+    void NewProjectMenu::AddProjectFolderNameTextBox_TextChanged(const IInspectable& sender, const Controls::TextChangedEventArgs& /*e*/)
+    {
+        const auto isTextEmpty = sender.as<Controls::TextBox>().Text().empty();
+        AddProjectFolderButton().IsEnabled(!isTextEmpty);
+    }
+
+    DataTemplate NewProjectMenuEntryTemplateSelector::SelectTemplateCore(const IInspectable& item, const DependencyObject& /*container*/)
+    {
+        return SelectTemplateCore(item);
+    }
+
+    DataTemplate NewProjectMenuEntryTemplateSelector::SelectTemplateCore(const IInspectable& item)
+    {
+        if (const auto entryVM = item.try_as<Editor::NewProjectMenuEntryViewModel>())
+        {
+            switch (entryVM.Type())
+            {
+            case Model::NewProjectMenuEntryType::Project:
+                return ProjectEntryTemplate();
+            case Model::NewProjectMenuEntryType::ProjectAction:
+                return ProjectActionEntryTemplate();
+            case Model::NewProjectMenuEntryType::ProjectSeparator:
+                return ProjectSeparatorEntryTemplate();
+            case Model::NewProjectMenuEntryType::ProjectFolder:
+                return ProjectFolderEntryTemplate();
+            case Model::NewProjectMenuEntryType::ProjectMatch:
+                return ProjectMatchEntryTemplate();
+            case Model::NewProjectMenuEntryType::ProjectRemaining:
+                return ProjectRemainingEntryTemplate();
+            case Model::NewProjectMenuEntryType::Invalid:
+            default:
+                assert(false);
+                return nullptr;
+            }
+        }
+        assert(false);
+        return nullptr;
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenu.h
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenu.h
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "NewProjectMenu.g.h"
+#include "NewProjectMenuEntryTemplateSelector.g.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct NewProjectMenu : public HasScrollViewer<NewProjectMenu>, NewProjectMenuT<NewProjectMenu>
+    {
+    public:
+        NewProjectMenu();
+
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+
+        // FolderPickerDialog handlers
+        void ProjectFolderPickerDialog_Opened(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::Controls::ContentDialogOpenedEventArgs& e);
+        void ProjectFolderPickerDialog_PrimaryButtonClick(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs& e);
+
+        // NTM Entry handlers
+        void ProjectEditEntry_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void ProjectReorderEntry_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void ProjectDeleteEntry_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+
+        // Multiple Entry handlers
+        safe_void_coroutine ProjectMoveMultiple_Click(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void ProjectDeleteMultiple_Click(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+
+        // New Entry handlers
+        void AddProjectButton_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void AddProjectSeparatorButton_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void AddProjectFolderButton_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void AddProjectMatchButton_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void AddProjectRemainingButton_Clicked(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+        void AddProjectFolderNameTextBox_KeyDown(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
+        void AddProjectFolderNameTextBox_TextChanged(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::Controls::TextChangedEventArgs& e);
+
+        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        WINRT_OBSERVABLE_PROPERTY(Editor::NewProjectMenuViewModel, ViewModel, _PropertyChangedHandlers, nullptr);
+
+    private:
+        Editor::NewProjectMenuEntryViewModel _draggedEntry{ nullptr };
+
+        void _ScrollToEntry(const Editor::NewProjectMenuEntryViewModel& entry);
+    };
+
+    struct NewProjectMenuEntryTemplateSelector : public NewProjectMenuEntryTemplateSelectorT<NewProjectMenuEntryTemplateSelector>
+    {
+    public:
+        NewProjectMenuEntryTemplateSelector() = default;
+
+        Windows::UI::Xaml::DataTemplate SelectTemplateCore(const Windows::Foundation::IInspectable& item, const Windows::UI::Xaml::DependencyObject& container);
+        Windows::UI::Xaml::DataTemplate SelectTemplateCore(const Windows::Foundation::IInspectable& item);
+
+        WINRT_PROPERTY(Windows::UI::Xaml::DataTemplate, ProjectEntryTemplate, nullptr);
+        WINRT_PROPERTY(Windows::UI::Xaml::DataTemplate, ProjectActionEntryTemplate, nullptr);
+        WINRT_PROPERTY(Windows::UI::Xaml::DataTemplate, ProjectSeparatorEntryTemplate, nullptr);
+        WINRT_PROPERTY(Windows::UI::Xaml::DataTemplate, ProjectFolderEntryTemplate, nullptr);
+        WINRT_PROPERTY(Windows::UI::Xaml::DataTemplate, ProjectMatchEntryTemplate, nullptr);
+        WINRT_PROPERTY(Windows::UI::Xaml::DataTemplate, ProjectRemainingEntryTemplate, nullptr);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(NewProjectMenu);
+    BASIC_FACTORY(NewProjectMenuEntryTemplateSelector);
+}

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenu.idl
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenu.idl
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "NewProjectMenuViewModel.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    [default_interface] runtimeclass NewProjectMenu : Windows.UI.Xaml.Controls.Page
+    {
+        NewProjectMenu();
+        NewProjectMenuViewModel ViewModel { get; };
+    }
+
+    [default_interface] runtimeclass NewProjectMenuEntryTemplateSelector : Windows.UI.Xaml.Controls.DataTemplateSelector
+    {
+        NewProjectMenuEntryTemplateSelector();
+
+        Windows.UI.Xaml.DataTemplate ProjectEntryTemplate;
+        Windows.UI.Xaml.DataTemplate ProjectActionEntryTemplate;
+        Windows.UI.Xaml.DataTemplate ProjectSeparatorEntryTemplate;
+        Windows.UI.Xaml.DataTemplate ProjectFolderEntryTemplate;
+        Windows.UI.Xaml.DataTemplate ProjectMatchEntryTemplate;
+        Windows.UI.Xaml.DataTemplate ProjectRemainingEntryTemplate;
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenu.xaml
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenu.xaml
@@ -127,7 +127,7 @@
                 </ContentControl>
             </DataTemplate>
 
-            <DataTemplate x:Key="FolderEntryTemplate" x:DataType="local:FolderEntryViewModel">
+            <DataTemplate x:Key="ProjectFolderEntryTemplate" x:DataType="local:ProjectFolderEntryViewModel">
                 <!--
                     Most of this was copied from NewProjectMenuEntryControlsWrapper.
                     We really just added the Edit button here.
@@ -165,14 +165,14 @@
                         Spacing="5">
                         <Button
                             x:Uid="NewProjectMenuEntry_EditFolder"
-                            Click="EditEntry_Clicked"
+                            Click="ProjectEditEntry_Clicked"
                             DataContext="{Binding Mode=OneWay}"
                             Style="{StaticResource ExtraSmallButtonStyle}">
                             <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE70F;" />
                         </Button>
                         <Button
                             x:Uid="NewProjectMenuEntry_ReorderUp"
-                            Click="ReorderEntry_Clicked"
+                            Click="ProjectReorderEntry_Clicked"
                             DataContext="{Binding Mode=OneWay}"
                             Style="{StaticResource ExtraSmallButtonStyle}"
                             Tag="Up">
@@ -180,7 +180,7 @@
                         </Button>
                         <Button
                             x:Uid="NewProjectMenuEntry_ReorderDown"
-                            Click="ReorderEntry_Clicked"
+                            Click="ProjectReorderEntry_Clicked"
                             DataContext="{Binding Mode=OneWay}"
                             Style="{StaticResource ExtraSmallButtonStyle}"
                             Tag="Down">
@@ -188,7 +188,7 @@
                         </Button>
                         <Button
                             x:Uid="NewProjectMenuEntry_Delete"
-                            Click="DeleteEntry_Clicked"
+                            Click="ProjectDeleteEntry_Clicked"
                             DataContext="{Binding Mode=OneWay}"
                             Style="{StaticResource DeleteExtraSmallButtonStyle}">
                             <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE74D;" />
@@ -431,7 +431,7 @@
                         x:Uid="NewProjectMenu_AddFolder_FolderName"
                         MinWidth="{StaticResource StandardBoxMinWidth}"
                         KeyDown="AddProjectFolderNameTextBox_KeyDown"
-                        Text="{x:Bind ViewModel.AddFolderName, Mode=TwoWay}"
+                        Text="{x:Bind ViewModel.AddProjectFolderName, Mode=TwoWay}"
                         TextChanged="AddProjectFolderNameTextBox_TextChanged" />
                     <Button
                         x:Name="AddProjectFolderButton"

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenu.xaml
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenu.xaml
@@ -1,0 +1,490 @@
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+    the MIT License. See LICENSE in the project root for license information.
+-->
+<Page
+    x:Class="Microsoft.Terminal.Settings.Editor.NewProjectMenu"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Microsoft.Terminal.Settings.Editor"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:model="using:Microsoft.Terminal.Settings.Model"
+    xmlns:mtu="using:Microsoft.Terminal.UI"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <!--  Wrapper for NewProjectMenuEntry that adds buttons to the ListView entries  -->
+            <Style x:Key="NewProjectMenuEntryControlsWrapper" TargetType="ContentControl">
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ContentControl">
+                            <Grid XYFocusKeyboardNavigation="Enabled">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <!--
+                                    BODGY: We want two columns of content:
+                                    1. the identifier (e.g. Project name), aligned left
+                                    2. the buttons (e.g. reorder, delete), aligned right
+                                    There's a bug in WinUI 2 for Windows 10 where these nested columns are treated as "auto" instead
+                                    of *-sized. To work around this, we can set the width of the first column's content to
+                                    StandardControlMaxWidth. The first column will be clipped as necessary to make space for the second column,
+                                    resulting in the desired layout.
+                                -->
+                                <ContentPresenter
+                                    Grid.Column="0"
+                                    Width="{StaticResource StandardControlMaxWidth}"
+                                    Content="{TemplateBinding Content}" />
+                                <StackPanel
+                                    Grid.Column="1"
+                                    Orientation="Horizontal"
+                                    Spacing="5">
+                                    <!--  Reorder: Up  -->
+                                    <Button
+                                        x:Uid="NewProjectMenuEntry_ReorderUp"
+                                        Click="ProjectReorderEntry_Clicked"
+                                        DataContext="{TemplateBinding DataContext}"
+                                        Style="{StaticResource ExtraSmallButtonStyle}"
+                                        Tag="Up">
+                                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xF0AD;" />
+                                    </Button>
+                                    <!--  Reorder: Down  -->
+                                    <Button
+                                        x:Uid="NewProjectMenuEntry_ReorderDown"
+                                        Click="ProjectReorderEntry_Clicked"
+                                        DataContext="{TemplateBinding DataContext}"
+                                        Style="{StaticResource ExtraSmallButtonStyle}"
+                                        Tag="Down">
+                                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xF0AE;" />
+                                    </Button>
+                                    <!--  Delete Entry  -->
+                                    <Button
+                                        x:Uid="NewProjectMenuEntry_Delete"
+                                        Click="ProjectDeleteEntry_Clicked"
+                                        DataContext="{TemplateBinding DataContext}"
+                                        Style="{StaticResource DeleteExtraSmallButtonStyle}">
+                                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE74D;" />
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <DataTemplate x:Key="ProjectEntryTemplate" x:DataType="local:ProjectEntryViewModel">
+                <ContentControl
+                    AutomationProperties.Name="{x:Bind ProjectEntry.Project.Name, Mode=OneWay}"
+                    DataContext="{Binding Mode=OneWay}"
+                    Style="{StaticResource NewProjectMenuEntryControlsWrapper}">
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <IconSourceElement
+                            Width="16"
+                            Height="16"
+                            VerticalAlignment="Center"
+                            IconSource="{x:Bind mtu:IconPathConverter.IconSourceWUX(ProjectEntry.Project.EvaluatedIcon), Mode=OneTime}" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Bind ProjectEntry.Project.Name, Mode=OneWay}" />
+                    </StackPanel>
+                </ContentControl>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ProjectActionEntryTemplate" x:DataType="local:ProjectActionEntryViewModel">
+                <ContentControl
+                    AutomationProperties.Name="{x:Bind DisplayText, Mode=OneWay}"
+                    DataContext="{Binding Mode=OneWay}"
+                    Style="{StaticResource NewProjectMenuEntryControlsWrapper}">
+                    <StackPanel Orientation="Horizontal">
+                        <IconSourceElement
+                            Width="16"
+                            Height="16"
+                            Margin="0,0,10,0"
+                            VerticalAlignment="Center"
+                            IconSource="{x:Bind mtu:IconPathConverter.IconSourceWUX(Icon), Mode=OneWay}"
+                            Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Icon), Mode=OneWay}" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Bind DisplayText, Mode=OneWay}" />
+                    </StackPanel>
+                </ContentControl>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ProjectSeparatorEntryTemplate" x:DataType="local:ProjectSeparatorEntryViewModel">
+                <ContentControl
+                    x:Uid="NewProjectMenuEntry_SeparatorItem"
+                    DataContext="{Binding Mode=OneWay}"
+                    Style="{StaticResource NewProjectMenuEntryControlsWrapper}">
+                    <TextBlock
+                        x:Uid="NewProjectMenuEntry_Separator"
+                        VerticalAlignment="Center"
+                        FontStyle="Italic" />
+                </ContentControl>
+            </DataTemplate>
+
+            <DataTemplate x:Key="FolderEntryTemplate" x:DataType="local:FolderEntryViewModel">
+                <!--
+                    Most of this was copied from NewProjectMenuEntryControlsWrapper.
+                    We really just added the Edit button here.
+                -->
+                <Grid AutomationProperties.Name="{x:Bind Name, Mode=OneWay}" XYFocusKeyboardNavigation="Enabled">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <!--
+                        BODGY: We want two columns of content:
+                        1. the identifier (e.g. Project name), aligned left
+                        2. the buttons (e.g. reorder, delete), aligned right
+                        There's a bug in WinUI 2 for Windows 10 where these nested columns are treated as "auto" instead
+                        of *-sized. To work around this, we can set the width of the first column's content to
+                        StandardControlMaxWidth. The first column will be clipped as necessary to make space for the second column,
+                        resulting in the desired layout.
+                    -->
+                    <StackPanel
+                        Grid.Column="0"
+                        Width="{StaticResource StandardControlMaxWidth}"
+                        Orientation="Horizontal">
+                        <IconSourceElement
+                            Width="16"
+                            Height="16"
+                            Margin="0,0,10,0"
+                            VerticalAlignment="Center"
+                            IconSource="{x:Bind mtu:IconPathConverter.IconSourceWUX(Icon), Mode=OneWay}"
+                            Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Icon), Mode=OneWay}" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
+                    </StackPanel>
+                    <StackPanel
+                        Grid.Column="1"
+                        Orientation="Horizontal"
+                        Spacing="5">
+                        <Button
+                            x:Uid="NewProjectMenuEntry_EditFolder"
+                            Click="EditEntry_Clicked"
+                            DataContext="{Binding Mode=OneWay}"
+                            Style="{StaticResource ExtraSmallButtonStyle}">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE70F;" />
+                        </Button>
+                        <Button
+                            x:Uid="NewProjectMenuEntry_ReorderUp"
+                            Click="ReorderEntry_Clicked"
+                            DataContext="{Binding Mode=OneWay}"
+                            Style="{StaticResource ExtraSmallButtonStyle}"
+                            Tag="Up">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xF0AD;" />
+                        </Button>
+                        <Button
+                            x:Uid="NewProjectMenuEntry_ReorderDown"
+                            Click="ReorderEntry_Clicked"
+                            DataContext="{Binding Mode=OneWay}"
+                            Style="{StaticResource ExtraSmallButtonStyle}"
+                            Tag="Down">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xF0AE;" />
+                        </Button>
+                        <Button
+                            x:Uid="NewProjectMenuEntry_Delete"
+                            Click="DeleteEntry_Clicked"
+                            DataContext="{Binding Mode=OneWay}"
+                            Style="{StaticResource DeleteExtraSmallButtonStyle}">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE74D;" />
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ProjectMatchEntryTemplate" x:DataType="local:ProjectMatchEntryViewModel">
+                <ContentControl
+                    AutomationProperties.Name="{x:Bind DisplayText, Mode=OneWay}"
+                    DataContext="{Binding Mode=OneWay}"
+                    Style="{StaticResource NewProjectMenuEntryControlsWrapper}">
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontStyle="Italic"
+                        Text="{x:Bind DisplayText, Mode=OneWay}" />
+                </ContentControl>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ProjectRemainingEntryTemplate" x:DataType="local:ProjectRemainingEntryViewModel">
+                <ContentControl
+                    x:Uid="NewProjectMenuEntry_ProjectRemainingItem"
+                    DataContext="{Binding Mode=OneWay}"
+                    Style="{StaticResource NewProjectMenuEntryControlsWrapper}">
+                    <TextBlock
+                        x:Uid="NewProjectMenuEntry_ProjectRemaining"
+                        VerticalAlignment="Center"
+                        FontStyle="Italic" />
+                </ContentControl>
+            </DataTemplate>
+
+            <local:NewProjectMenuEntryTemplateSelector
+                x:Key="NewProjectMenuEntryTemplateSelector"
+                ProjectActionEntryTemplate="{StaticResource ProjectActionEntryTemplate}"
+                ProjectEntryTemplate="{StaticResource ProjectEntryTemplate}"
+                ProjectFolderEntryTemplate="{StaticResource ProjectFolderEntryTemplate}"
+                ProjectMatchEntryTemplate="{StaticResource ProjectMatchEntryTemplate}"
+                ProjectRemainingEntryTemplate="{StaticResource ProjectRemainingEntryTemplate}"
+                ProjectSeparatorEntryTemplate="{StaticResource ProjectSeparatorEntryTemplate}" />
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <Grid Margin="{StaticResource SettingStackMargin}" RowSpacing="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!--  Folder Picker Dialog: used to select a folder to move entries to  -->
+        <ContentDialog
+            x:Name="ProjectFolderPickerDialog"
+            x:Uid="NewProjectMenu_ProjectFolderPickerDialog"
+            x:Load="False"
+            DefaultButton="Primary"
+            Opened="ProjectFolderPickerDialog_Opened"
+            PrimaryButtonClick="ProjectFolderPickerDialog_PrimaryButtonClick">
+            <muxc:TreeView
+                x:Name="ProjectFolderTreeView"
+                ItemsSource="{x:Bind ViewModel.ProjectFolderTree, Mode=OneWay}"
+                SelectedItem="{x:Bind ViewModel.CurrentProjectFolderTreeViewSelectedItem, Mode=TwoWay}"
+                SelectionMode="Single">
+                <muxc:TreeView.ItemTemplate>
+                    <DataTemplate x:DataType="local:ProjectFolderTreeViewEntry">
+                        <muxc:TreeViewItem
+                            AutomationProperties.Name="{x:Bind Name, Mode=OneWay}"
+                            IsExpanded="True"
+                            ItemsSource="{x:Bind Children, Mode=OneWay}">
+                            <StackPanel AutomationProperties.Name="{x:Bind Name, Mode=OneWay}" Orientation="Horizontal">
+                                <IconSourceElement
+                                    Width="16"
+                                    Height="16"
+                                    Margin="0,0,10,0"
+                                    VerticalAlignment="Center"
+                                    IconSource="{x:Bind mtu:IconPathConverter.IconSourceWUX(Icon), Mode=OneWay}"
+                                    Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Icon), Mode=OneWay}" />
+                                <TextBlock VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
+                            </StackPanel>
+                        </muxc:TreeViewItem>
+                    </DataTemplate>
+                </muxc:TreeView.ItemTemplate>
+            </muxc:TreeView>
+        </ContentDialog>
+
+        <!--  New Tab Menu Content  -->
+        <StackPanel
+            Grid.Row="0"
+            MaxWidth="{StaticResource StandardControlMaxWidth}"
+            Spacing="10">
+            <Border
+                Height="300"
+                MaxWidth="{StaticResource StandardControlMaxWidth}"
+                Margin="0,12,0,0"
+                BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
+                BorderThickness="1"
+                CornerRadius="{ThemeResource ControlCornerRadius}">
+                <ListView
+                    x:Name="NewProjectMenuListView"
+                    AllowDrop="True"
+                    CanDragItems="True"
+                    CanReorderItems="True"
+                    ItemTemplateSelector="{StaticResource NewProjectMenuEntryTemplateSelector}"
+                    ItemsSource="{x:Bind ViewModel.ProjectCurrentView, Mode=OneWay}"
+                    SelectionMode="Multiple" />
+            </Border>
+
+            <!--  General Controls  -->
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <Button
+                    x:Name="ProjectMoveToFolderButton"
+                    Click="ProjectMoveMultiple_Click"
+                    IsEnabled="False">
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE8DE;" />
+                        <TextBlock x:Uid="NewProjectMenu_MoveToFolderTextBlock" Margin="10,0,0,0" />
+                    </StackPanel>
+                </Button>
+                <Button
+                    x:Name="ProjectDeleteMultipleButton"
+                    Click="ProjectDeleteMultiple_Click"
+                    IsEnabled="False"
+                    Style="{StaticResource DeleteButtonStyle}">
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE74D;" />
+                        <TextBlock x:Uid="NewProjectMenu_DeleteMultipleTextBlock" Margin="10,0,0,0" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+        </StackPanel>
+
+        <!--  Folder View Controls  -->
+        <StackPanel
+            Grid.Row="1"
+            MaxWidth="{StaticResource StandardControlMaxWidth}"
+            Visibility="{x:Bind ViewModel.IsProjectFolderView, Mode=OneWay}">
+            <TextBlock x:Uid="NewProjectMenu_CurrentFolderTextBlock" Style="{StaticResource TextBlockSubHeaderStyle}" />
+
+            <!--  TODO GH #18281: Icon  -->
+            <!--  Once PR #17965 merges, we can add that kind of control to set an icon  -->
+
+            <!--  Name  -->
+            <local:SettingContainer
+                x:Uid="NewProjectMenu_CurrentFolderName"
+                Grid.Row="0"
+                CurrentValue="{x:Bind ViewModel.CurrentFolderName, Mode=OneWay}"
+                Style="{StaticResource ExpanderSettingContainerStyle}">
+                <TextBox Style="{StaticResource TextBoxSettingStyle}" Text="{x:Bind ViewModel.CurrentFolderName, Mode=TwoWay}" />
+            </local:SettingContainer>
+
+            <!--  Inlining  -->
+            <local:SettingContainer x:Uid="NewProjectMenu_CurrentFolderInlining" Grid.Row="1">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.CurrentFolderInlining, Mode=TwoWay}" Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Allow Empty  -->
+            <local:SettingContainer x:Uid="NewProjectMenu_CurrentFolderAllowEmpty" Grid.Row="2">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.CurrentFolderAllowEmpty, Mode=TwoWay}" Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+        </StackPanel>
+
+        <!--  Add Entries  -->
+        <StackPanel Grid.Row="2">
+            <TextBlock x:Uid="NewProjectMenu_AddEntriesTextBlock" Style="{StaticResource TextBlockSubHeaderStyle}" />
+
+            <!--  Add Project  -->
+            <local:SettingContainer
+                x:Uid="NewProjectMenu_AddProject"
+                FontIconGlyph="&#xE756;"
+                Style="{StaticResource SettingContainerWithIcon}">
+
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <!--  Select Project to add  -->
+                    <ComboBox
+                        x:Name="AddProjectComboBox"
+                        MinWidth="{StaticResource StandardBoxMinWidth}"
+                        ItemsSource="{x:Bind ViewModel.AvailableProjects, Mode=OneWay}"
+                        SelectedItem="{x:Bind ViewModel.SelectedProject, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="model:Project">
+                                <Grid HorizontalAlignment="Stretch" ColumnSpacing="8">
+
+                                    <Grid.ColumnDefinitions>
+                                        <!--  icon  -->
+                                        <ColumnDefinition Width="16" />
+                                        <!--  Project name  -->
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <IconSourceElement
+                                        Grid.Column="0"
+                                        Width="16"
+                                        Height="16"
+                                        IconSource="{x:Bind mtu:IconPathConverter.IconSourceWUX(EvaluatedIcon), Mode=OneTime}" />
+
+                                    <TextBlock Grid.Column="1" Text="{x:Bind Name}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+
+                    <Button
+                        x:Name="AddProjectButton"
+                        x:Uid="NewProjectMenu_AddProjectButton"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        Click="AddProjectButton_Clicked">
+                        <Button.Content>
+                            <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE710;" />
+                        </Button.Content>
+                    </Button>
+                </StackPanel>
+            </local:SettingContainer>
+
+            <!--  Add Separator  -->
+            <local:SettingContainer
+                x:Uid="NewProjectMenu_AddProjectSeparator"
+                FontIconGlyph="&#xE76f;"
+                Style="{StaticResource SettingContainerWithIcon}">
+                <Button
+                    x:Name="AddProjectSeparatorButton"
+                    x:Uid="NewProjectMenu_AddSeparatorButton"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Click="AddProjectSeparatorButton_Clicked">
+                    <Button.Content>
+                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE710;" />
+                    </Button.Content>
+                </Button>
+            </local:SettingContainer>
+
+            <!--  Add Folder  -->
+            <local:SettingContainer
+                x:Uid="NewProjectMenu_AddFolder"
+                FontIconGlyph="&#xF12B;"
+                Style="{StaticResource SettingContainerWithIcon}">
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <TextBox
+                        x:Name="ProjectFolderNameTextBox"
+                        x:Uid="NewProjectMenu_AddFolder_FolderName"
+                        MinWidth="{StaticResource StandardBoxMinWidth}"
+                        KeyDown="AddProjectFolderNameTextBox_KeyDown"
+                        Text="{x:Bind ViewModel.AddFolderName, Mode=TwoWay}"
+                        TextChanged="AddProjectFolderNameTextBox_TextChanged" />
+                    <Button
+                        x:Name="AddProjectFolderButton"
+                        x:Uid="NewProjectMenu_AddFolderButton"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        Click="AddProjectFolderButton_Clicked"
+                        IsEnabled="False">
+                        <Button.Content>
+                            <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE710;" />
+                        </Button.Content>
+                    </Button>
+                </StackPanel>
+            </local:SettingContainer>
+
+            <!--  Add Project Match  -->
+            <local:SettingContainer
+                x:Uid="NewProjectMenu_AddProjectMatch"
+                FontIconGlyph="&#xE748;"
+                Style="{StaticResource ExpanderSettingContainerStyleWithIcon}">
+                <StackPanel Spacing="10">
+                    <HyperlinkButton x:Uid="NewProjectMenu_AddProjectMatch_Help" NavigateUri="https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference" />
+                    <TextBox x:Uid="NewProjectMenu_AddProjectMatch_Name" Text="{x:Bind ViewModel.ProjectMatcherName, Mode=TwoWay}" />
+                    <TextBox x:Uid="NewProjectMenu_AddProjectMatch_Source" Text="{x:Bind ViewModel.ProjectMatcherSource, Mode=TwoWay}" />
+                    <TextBox x:Uid="NewProjectMenu_AddProjectMatch_Commandline" Text="{x:Bind ViewModel.ProjectMatcherCommandline, Mode=TwoWay}" />
+                    <Button x:Name="AddProjectMatchButton" Click="AddProjectMatchButton_Clicked">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE710;" />
+                                <TextBlock x:Uid="NewProjectMenu_AddProjectMatchTextBlock" Style="{StaticResource IconButtonTextBlockStyle}" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+                </StackPanel>
+            </local:SettingContainer>
+
+            <!--  Add Project Remaining  -->
+            <local:SettingContainer
+                x:Uid="NewProjectMenu_AddProjectRemaining"
+                FontIconGlyph="&#xE902;"
+                Style="{StaticResource SettingContainerWithIcon}">
+                <Button
+                    x:Name="AddProjectRemainingButton"
+                    x:Uid="NewProjectMenu_AddProjectRemainingButton"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Click="AddProjectRemainingButton_Clicked"
+                    IsEnabled="{x:Bind ViewModel.IsProjectRemainingEntryMissing, Mode=OneWay}">
+                    <Button.Content>
+                        <FontIcon FontSize="{StaticResource StandardIconSize}" Glyph="&#xE710;" />
+                    </Button.Content>
+                </Button>
+            </local:SettingContainer>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.cpp
@@ -1,0 +1,678 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "NewProjectMenuViewModel.h"
+#include <LibraryResources.h>
+
+#include "NewProjectMenuViewModel.g.cpp"
+#include "ProjectFolderTreeViewEntry.g.cpp"
+#include "NewProjectMenuEntryViewModel.g.cpp"
+#include "ProjectEntryViewModel.g.cpp"
+#include "ProjectActionEntryViewModel.g.cpp"
+#include "ProjectSeparatorEntryViewModel.g.cpp"
+#include "ProjectFolderEntryViewModel.g.cpp"
+#include "ProjectMatchEntryViewModel.g.cpp"
+#include "ProjectRemainingEntryViewModel.g.cpp"
+
+using namespace winrt::Windows::UI::Xaml::Navigation;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+using namespace winrt::Windows::UI::Xaml::Data;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+	static IObservableVector<Editor::NewProjectMenuEntryViewModel> _ConvertToViewModelEntries(const IVector<Model::NewProjectMenuEntry>& settingsModelEntries, const Model::CascadiaSettings& settings)
+	{
+		std::vector<Editor::NewProjectMenuEntryViewModel> result{};
+		if (!settingsModelEntries)
+		{
+			return single_threaded_observable_vector<Editor::NewProjectMenuEntryViewModel>(std::move(result));
+		}
+
+		for (const auto& entry : settingsModelEntries)
+		{
+			switch (entry.Type())
+			{
+			case NewProjectMenuEntryType::Project:
+			{
+				// If the Project isn't set, this is an invalid entry. Skip it.
+				if (const auto& projectEntry = entry.as<Model::ProjectEntry>(); projectEntry.Project())
+				{
+					result.push_back(make<ProjectEntryViewModel>(projectEntry));
+				}
+				break;
+			}
+			case NewProjectMenuEntryType::ProjectAction:
+			{
+				if (const auto& actionEntry = entry.as<Model::ProjectActionEntry>())
+				{
+					result.push_back(make<ProjectActionEntryViewModel>(actionEntry, settings));
+				}
+				break;
+			}
+			case NewProjectMenuEntryType::ProjectSeparator:
+			{
+				if (const auto& separatorEntry = entry.as<Model::ProjectSeparatorEntry>())
+				{
+					result.push_back(make<ProjectSeparatorEntryViewModel>(separatorEntry));
+				}
+				break;
+			}
+			case NewProjectMenuEntryType::ProjectFolder:
+			{
+				if (const auto& folderEntry = entry.as<Model::ProjectFolderEntry>())
+				{
+					// The ctor will convert the children of the folder to view models
+					result.push_back(make<ProjectFolderEntryViewModel>(folderEntry, settings));
+				}
+				break;
+			}
+			case NewProjectMenuEntryType::ProjectMatch:
+			{
+				if (const auto& projectMatchEntry = entry.as<Model::ProjectMatchEntry>())
+				{
+					result.push_back(make<ProjectMatchEntryViewModel>(projectMatchEntry));
+				}
+				break;
+			}
+			case NewProjectMenuEntryType::ProjectRemaining:
+			{
+				if (const auto& projectRemainingEntry = entry.as<Model::ProjectRemainingEntry>())
+				{
+					result.push_back(make<ProjectRemainingEntryViewModel>(projectRemainingEntry));
+				}
+				break;
+			}
+			case NewProjectMenuEntryType::Invalid:
+			default:
+				break;
+			}
+		}
+		return single_threaded_observable_vector<Editor::NewProjectMenuEntryViewModel>(std::move(result));
+	}
+
+	bool NewProjectMenuViewModel::IsProjectRemainingEntryMissing() const
+	{
+		return _IsProjectRemainingEntryMissing(_rootEntries);
+	}
+
+	bool NewProjectMenuViewModel::_IsProjectRemainingEntryMissing(const IVector<Editor::NewProjectMenuEntryViewModel>& entries)
+	{
+		for (const auto& entry : entries)
+		{
+			switch (entry.Type())
+			{
+			case NewProjectMenuEntryType::ProjectRemaining:
+			{
+				return false;
+			}
+			case NewProjectMenuEntryType::ProjectFolder:
+			{
+				if (!_IsProjectRemainingEntryMissing(entry.as<Editor::ProjectFolderEntryViewModel>().Entries()))
+				{
+					return false;
+				}
+				break;
+			}
+			default:
+				break;
+			}
+		}
+		return true;
+	}
+
+	bool NewProjectMenuViewModel::IsProjectFolderView() const noexcept
+	{
+		return _CurrentProjectFolder != nullptr;
+	}
+
+	NewProjectMenuViewModel::NewProjectMenuViewModel(Model::CascadiaSettings settings)
+	{
+		UpdateSettings(settings);
+
+		// Add a property changed handler to our own property changed event.
+		// This propagates changes from the settings model to anybody listening to our
+		// unique view model members.
+		PropertyChanged([this](auto&&, const PropertyChangedEventArgs& args) {
+			const auto viewModelProperty{ args.PropertyName() };
+			if (viewModelProperty == L"AvailableProjects")
+			{
+				_NotifyChanges(L"SelectedProject");
+			}
+			else if (viewModelProperty == L"CurrentProjectFolder")
+			{
+				if (_CurrentProjectFolder)
+				{
+					CurrentFolderName(_CurrentProjectFolder.Name());
+					_CurrentProjectFolder.PropertyChanged({ this, &NewProjectMenuViewModel::_FolderPropertyChanged });
+				}
+				_NotifyChanges(L"IsProjectFolderView", L"ProjectCurrentView");
+			}
+		});
+	}
+
+	void NewProjectMenuViewModel::_FolderPropertyChanged(const IInspectable& /*sender*/, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args)
+	{
+		const auto viewModelProperty{ args.PropertyName() };
+		if (viewModelProperty == L"Name")
+		{
+			// FolderTree needs to be updated when a folder is renamed
+			_folderTreeCache = nullptr;
+		}
+	}
+
+	hstring NewProjectMenuViewModel::CurrentFolderName() const
+	{
+		if (!_CurrentProjectFolder)
+		{
+			return {};
+		}
+		return _CurrentProjectFolder.Name();
+	}
+
+	void NewProjectMenuViewModel::CurrentFolderName(const hstring& value)
+	{
+		if (_CurrentProjectFolder && _CurrentProjectFolder.Name() != value)
+		{
+			_CurrentProjectFolder.Name(value);
+			_NotifyChanges(L"CurrentFolderName");
+		}
+	}
+
+	bool NewProjectMenuViewModel::CurrentFolderInlining() const
+	{
+		if (!_CurrentProjectFolder)
+		{
+			return {};
+		}
+		return _CurrentProjectFolder.Inlining();
+	}
+
+	void NewProjectMenuViewModel::CurrentFolderInlining(bool value)
+	{
+		if (_CurrentProjectFolder && _CurrentProjectFolder.Inlining() != value)
+		{
+			_CurrentProjectFolder.Inlining(value);
+			_NotifyChanges(L"CurrentFolderInlining");
+		}
+	}
+
+	bool NewProjectMenuViewModel::CurrentFolderAllowEmpty() const
+	{
+		if (!_CurrentProjectFolder)
+		{
+			return {};
+		}
+		return _CurrentProjectFolder.AllowEmpty();
+	}
+
+	void NewProjectMenuViewModel::CurrentFolderAllowEmpty(bool value)
+	{
+		if (_CurrentProjectFolder && _CurrentProjectFolder.AllowEmpty() != value)
+		{
+			_CurrentProjectFolder.AllowEmpty(value);
+			_NotifyChanges(L"CurrentFolderAllowEmpty");
+		}
+	}
+
+	Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel> NewProjectMenuViewModel::ProjectCurrentView() const
+	{
+		if (!_CurrentProjectFolder)
+		{
+			return _rootEntries;
+		}
+		return _CurrentProjectFolder.Entries();
+	}
+
+	static bool _FindFolderPathByName(const IVector<Editor::NewProjectMenuEntryViewModel>& entries, const hstring& name, std::vector<Editor::ProjectFolderEntryViewModel>& result)
+	{
+		for (const auto& entry : entries)
+		{
+			if (const auto& folderVM = entry.try_as<Editor::ProjectFolderEntryViewModel>())
+			{
+				result.push_back(folderVM);
+				if (folderVM.Name() == name)
+				{
+					// Found the folder
+					return true;
+				}
+				else if (_FindFolderPathByName(folderVM.Entries(), name, result))
+				{
+					// Found the folder in the children of this folder
+					return true;
+				}
+				else
+				{
+					// This folder and its descendants are not the folder we're looking for
+					result.pop_back();
+				}
+			}
+		}
+		return false;
+	}
+
+	IVector<Editor::ProjectFolderEntryViewModel> NewProjectMenuViewModel::FindFolderPathByName(const hstring& name)
+	{
+		std::vector<Editor::ProjectFolderEntryViewModel> entries;
+		_FindFolderPathByName(_rootEntries, name, entries);
+		return single_threaded_vector<Editor::ProjectFolderEntryViewModel>(std::move(entries));
+	}
+
+	void NewProjectMenuViewModel::UpdateSettings(const Model::CascadiaSettings& settings)
+	{
+		_Settings = settings;
+		_NotifyChanges(L"AvailableProjects");
+
+		SelectedProject(AvailableProjects().GetAt(0));
+
+		// TODO: remove pass nullptr
+		_rootEntries = _ConvertToViewModelEntries(nullptr, _Settings);
+		_rootEntriesChangedRevoker = _rootEntries.VectorChanged(winrt::auto_revoke, [this](auto&&, const IVectorChangedEventArgs& args) {
+			switch (args.CollectionChange())
+			{
+			case CollectionChange::Reset:
+			{
+				// fully replace settings model with view model structure
+				std::vector<Model::NewProjectMenuEntry> modelEntries;
+				for (const auto& entry : _rootEntries)
+				{
+					modelEntries.push_back(NewProjectMenuEntryViewModel::GetModel(entry));
+				}
+				_Settings.GlobalSettings().NewProjectMenu(single_threaded_vector<Model::NewProjectMenuEntry>(std::move(modelEntries)));
+				return;
+			}
+			case CollectionChange::ItemInserted:
+			{
+				const auto& insertedEntryVM = _rootEntries.GetAt(args.Index());
+				const auto& insertedEntry = NewProjectMenuEntryViewModel::GetModel(insertedEntryVM);
+				_Settings.GlobalSettings().NewProjectMenu().InsertAt(args.Index(), insertedEntry);
+				return;
+			}
+			case CollectionChange::ItemRemoved:
+			{
+				_Settings.GlobalSettings().NewProjectMenu().RemoveAt(args.Index());
+				return;
+			}
+			case CollectionChange::ItemChanged:
+			{
+				const auto& modifiedEntry = _rootEntries.GetAt(args.Index());
+				_Settings.GlobalSettings().NewProjectMenu().SetAt(args.Index(), NewProjectMenuEntryViewModel::GetModel(modifiedEntry));
+				return;
+			}
+			}
+		});
+	}
+
+	void NewProjectMenuViewModel::RequestReorderEntry(const Editor::NewProjectMenuEntryViewModel& vm, bool goingUp)
+	{
+		uint32_t idx;
+		if (ProjectCurrentView().IndexOf(vm, idx))
+		{
+			if (goingUp && idx > 0)
+			{
+				ProjectCurrentView().RemoveAt(idx);
+				ProjectCurrentView().InsertAt(idx - 1, vm);
+			}
+			else if (!goingUp && idx < ProjectCurrentView().Size() - 1)
+			{
+				ProjectCurrentView().RemoveAt(idx);
+				ProjectCurrentView().InsertAt(idx + 1, vm);
+			}
+		}
+	}
+
+	void NewProjectMenuViewModel::RequestDeleteEntry(const Editor::NewProjectMenuEntryViewModel& vm)
+	{
+		uint32_t idx;
+		if (ProjectCurrentView().IndexOf(vm, idx))
+		{
+			ProjectCurrentView().RemoveAt(idx);
+
+			if (vm.try_as<Editor::FolderEntryViewModel>())
+			{
+				_folderTreeCache = nullptr;
+			}
+		}
+	}
+
+	void NewProjectMenuViewModel::RequestMoveEntriesToFolder(const Windows::Foundation::Collections::IVector<Editor::NewProjectMenuEntryViewModel>& entries, const Editor::ProjectFolderEntryViewModel& destinationFolder)
+	{
+		auto destination{ destinationFolder == nullptr ? _rootEntries : destinationFolder.Entries() };
+		for (auto&& e : entries)
+		{
+			// Don't move the folder into itself (just skip over it)
+			if (e == destinationFolder)
+			{
+				continue;
+			}
+
+			// Remove entry from the current layer,
+			// and add it to the destination folder
+			RequestDeleteEntry(e);
+			destination.Append(e);
+		}
+	}
+
+	Editor::NewProjectMenuEntryViewModel NewProjectMenuViewModel::RequestAddSelectedProjectEntry()
+	{
+		if (_SelectedProject)
+		{
+			Model::ProjectEntry projectEntry;
+			projectEntry.Project(_SelectedProject);
+
+			const auto& entryVM = make<ProjectEntryViewModel>(projectEntry);
+			ProjectCurrentView().Append(entryVM);
+			return entryVM;
+		}
+		return nullptr;
+	}
+
+	Editor::NewProjectMenuEntryViewModel NewProjectMenuViewModel::RequestAddProjectSeparatorEntry()
+	{
+		Model::ProjectSeparatorEntry separatorEntry;
+		const auto& entryVM = make<ProjectSeparatorEntryViewModel>(separatorEntry);
+		ProjectCurrentView().Append(entryVM);
+		return entryVM;
+	}
+
+	Editor::NewProjectMenuEntryViewModel NewProjectMenuViewModel::RequestAddProjectFolderEntry()
+	{
+		Model::ProjectFolderEntry folderEntry;
+		folderEntry.Name(_AddProjectFolderName);
+
+		const auto& entryVM = make<FolderEntryViewModel>(folderEntry, _Settings);
+		ProjectCurrentView().Append(entryVM);
+
+		// Reset state after adding the entry
+		AddProjectFolderName({});
+		_folderTreeCache = nullptr;
+		return entryVM;
+	}
+
+	Editor::NewProjectMenuEntryViewModel NewProjectMenuViewModel::RequestAddProjectMatcherEntry()
+	{
+		Model::ProjectMatchEntry matchProjectsEntry;
+		matchProjectsEntry.Name(_ProjectMatcherName);
+		matchProjectsEntry.Source(_ProjectMatcherSource);
+		matchProjectsEntry.Commandline(_ProjectMatcherCommandline);
+
+		const auto& entryVM = make<ProjectMatchEntryViewModel>(matchProjectsEntry);
+		ProjectCurrentView().Append(entryVM);
+
+		// Clear the fields after adding the entry
+		ProjectMatcherName({});
+		ProjectMatcherSource({});
+		ProjectMatcherCommandline({});
+
+		return entryVM;
+	}
+
+	Editor::NewProjectMenuEntryViewModel NewProjectMenuViewModel::RequestAddProjectRemainingEntry()
+	{
+		Model::ProjectRemainingEntry remainingProjectsEntry;
+		const auto& entryVM = make<ProjectRemainingEntryViewModel>(remainingProjectsEntry);
+		ProjectCurrentView().Append(entryVM);
+
+		_NotifyChanges(L"IsProjectRemainingEntryMissing");
+
+		return entryVM;
+	}
+
+	void NewProjectMenuViewModel::GenerateFolderTree()
+	{
+		if (!_folderTreeCache)
+		{
+			// Add the root folder
+			auto root = winrt::make<FolderTreeViewEntry>(nullptr);
+
+			for (const auto&& entry : _rootEntries)
+			{
+				if (entry.Type() == NewProjectMenuEntryType::ProjectFolder)
+				{
+					root.Children().Append(winrt::make<ProjectFolderTreeViewEntry>(entry.as<Editor::ProjectFolderEntryViewModel>()));
+				}
+			}
+
+			std::vector<Editor::ProjectFolderTreeViewEntry> folderTreeCache;
+			folderTreeCache.emplace_back(std::move(root));
+			_folderTreeCache = single_threaded_observable_vector<Editor::ProjectFolderTreeViewEntry>(std::move(folderTreeCache));
+
+			_NotifyChanges(L"ProjectFolderTree");
+		}
+	}
+
+	Collections::IObservableVector<Editor::ProjectFolderTreeViewEntry> NewProjectMenuViewModel::FolderTree() const
+	{
+		// We could do this...
+		//   if (!_folderTreeCache){ GenerateFolderTree(); }
+		// But FolderTree() gets called when we open the page.
+		// Instead, we generate the tree as needed using GenerateFolderTree()
+		//  which caches the tree.
+		return _folderTreeCache;
+	}
+
+	// This recursively constructs the FolderTree
+	ProjectFolderTreeViewEntry::ProjectFolderTreeViewEntry(Editor::ProjectFolderEntryViewModel folderEntry) :
+		_folderEntry{ folderEntry },
+		_Children{ single_threaded_observable_vector<Editor::ProjectFolderTreeViewEntry>() }
+	{
+		if (!_folderEntry)
+		{
+			return;
+		}
+
+		for (const auto&& entry : _folderEntry.Entries())
+		{
+			if (entry.Type() == NewProjectMenuEntryType::ProjectFolder)
+			{
+				_Children.Append(winrt::make<ProjectFolderTreeViewEntry>(entry.as<Editor::ProjectFolderEntryViewModel>()));
+			}
+		}
+	}
+
+	hstring ProjectFolderTreeViewEntry::Name() const
+	{
+		if (!_folderEntry)
+		{
+			return RS_(L"NewProjectMenu_RootFolderName");
+		}
+		return _folderEntry.Name();
+	}
+
+	hstring ProjectFolderTreeViewEntry::Icon() const
+	{
+		if (!_folderEntry)
+		{
+			return {};
+		}
+		return _folderEntry.Icon();
+	}
+
+	NewProjectMenuEntryViewModel::NewProjectMenuEntryViewModel(const NewProjectMenuEntryType type) noexcept :
+		_Type{ type }
+	{
+	}
+
+	Model::NewProjectMenuEntry NewProjectMenuEntryViewModel::GetModel(const Editor::NewProjectMenuEntryViewModel& viewModel)
+	{
+		switch (viewModel.Type())
+		{
+		case NewProjectMenuEntryType::Project:
+		{
+			const auto& projVM = viewModel.as<Editor::ProjectEntryViewModel>();
+			return get_self<ProjectEntryViewModel>(projVM)->ProjectEntry();
+		}
+		case NewProjectMenuEntryType::ProjectAction:
+		{
+			const auto& projVM = viewModel.as<Editor::ActionEntryViewModel>();
+			return get_self<ProjectActionEntryViewModel>(projVM)->ProjectActionEntry();
+		}
+		case NewProjectMenuEntryType::ProjectSeparator:
+		{
+			const auto& projVM = viewModel.as<Editor::SeparatorEntryViewModel>();
+			return get_self<ProjectSeparatorEntryViewModel>(projVM)->ProjectSeparatorEntry();
+		}
+		case NewProjectMenuEntryType::ProjectFolder:
+		{
+			const auto& projVM = viewModel.as<Editor::FolderEntryViewModel>();
+			return get_self<ProjectFolderEntryViewModel>(projVM)->ProjectFolderEntry();
+		}
+		case NewProjectMenuEntryType::ProjectMatch:
+		{
+			const auto& projVM = viewModel.as<Editor::ProjectMatchEntryViewModel>();
+			return get_self<ProjectMatchEntryViewModel>(projVM)->ProjectMatchEntry();
+		}
+		case NewProjectMenuEntryType::ProjectRemaining:
+		{
+			const auto& projVM = viewModel.as<Editor::ProjectRemainingEntryViewModel>();
+			return get_self<ProjectRemainingEntryViewModel>(projVM)->ProjectRemainingEntry();
+		}
+		case NewProjectMenuEntryType::Invalid:
+		default:
+			return nullptr;
+		}
+	}
+
+	ProjectEntryViewModel::ProjectEntryViewModel(Model::ProjectEntry projectEntry) :
+		ProjectEntryViewModelT<ProjectEntryViewModel, NewProjectMenuEntryViewModel>(Model::NewProjectMenuEntryType::Project),
+		_ProjectEntry{ projectEntry }
+	{
+	}
+
+	ProjectActionEntryViewModel::ProjectActionEntryViewModel(Model::ProjectActionEntry actionEntry, Model::CascadiaSettings settings) :
+		ProjectActionEntryViewModelT<ProjectActionEntryViewModel, NewProjectMenuEntryViewModel>(Model::NewProjectMenuEntryType::ProjectAction),
+		_ProjectActionEntry{ actionEntry },
+		_Settings{ settings }
+	{
+	}
+
+	hstring ProjectActionEntryViewModel::DisplayText() const
+	{
+		assert(_Settings);
+
+		const auto actionID = _ProjectActionEntry.ActionId();
+		if (const auto& action = _Settings.ActionMap().GetActionByID(actionID))
+		{
+			return action.Name();
+		}
+		return hstring{ fmt::format(L"{}: {}", RS_(L"NewProjectMenu_ActionNotFound"), actionID) };
+	}
+
+	hstring ProjectActionEntryViewModel::Icon() const
+	{
+		assert(_Settings);
+
+		const auto actionID = _ProjectActionEntry.ActionId();
+		if (const auto& action = _Settings.ActionMap().GetActionByID(actionID))
+		{
+			return action.IconPath();
+		}
+		return {};
+	}
+
+	ProjectSeparatorEntryViewModel::ProjectSeparatorEntryViewModel(Model::ProjectSeparatorEntry separatorEntry) :
+		ProjectSeparatorEntryViewModelT<ProjectSeparatorEntryViewModel, NewProjectMenuEntryViewModel>(Model::NewProjectMenuEntryType::ProjectSeparator),
+		_ProjectSeparatorEntry{ separatorEntry }
+	{
+	}
+
+	ProjectFolderEntryViewModel::ProjectFolderEntryViewModel(Model::ProjectFolderEntry folderEntry) :
+		ProjectFolderEntryViewModel(folderEntry, nullptr) {}
+
+	ProjectFolderEntryViewModel::ProjectFolderEntryViewModel(Model::ProjectFolderEntry folderEntry, Model::CascadiaSettings settings) :
+		ProjectFolderEntryViewModelT<ProjectFolderEntryViewModel, NewProjectMenuEntryViewModel>(Model::NewProjectMenuEntryType::ProjectFolder),
+		_ProjectFolderEntry{ folderEntry },
+		_Settings{ settings }
+	{
+		_Entries = _ConvertToViewModelEntries(_ProjectFolderEntry.RawEntries(), _Settings);
+
+		_entriesChangedRevoker = _Entries.VectorChanged(winrt::auto_revoke, [this](auto&&, const IVectorChangedEventArgs& args) {
+			switch (args.CollectionChange())
+			{
+			case CollectionChange::Reset:
+			{
+				// fully replace settings model with _Entries
+				std::vector<Model::NewProjectMenuEntry> modelEntries;
+				for (const auto& entry : _Entries)
+				{
+					modelEntries.push_back(NewProjectMenuEntryViewModel::GetModel(entry));
+				}
+				_ProjectFolderEntry.RawEntries(single_threaded_vector<Model::NewProjectMenuEntry>(std::move(modelEntries)));
+				return;
+			}
+			case CollectionChange::ItemInserted:
+			{
+				const auto& insertedEntryVM = _Entries.GetAt(args.Index());
+				const auto& insertedEntry = NewProjectMenuEntryViewModel::GetModel(insertedEntryVM);
+				if (!_ProjectFolderEntry.RawEntries())
+				{
+					_ProjectFolderEntry.RawEntries(single_threaded_vector<Model::NewProjectMenuEntry>());
+				}
+				_ProjectFolderEntry.RawEntries().InsertAt(args.Index(), insertedEntry);
+				return;
+			}
+			case CollectionChange::ItemRemoved:
+			{
+				_ProjectFolderEntry.RawEntries().RemoveAt(args.Index());
+				return;
+			}
+			case CollectionChange::ItemChanged:
+			{
+				const auto& modifiedEntry = _Entries.GetAt(args.Index());
+				_ProjectFolderEntry.RawEntries().SetAt(args.Index(), NewProjectMenuEntryViewModel::GetModel(modifiedEntry));
+				return;
+			}
+			}
+		});
+	}
+
+	bool ProjectFolderEntryViewModel::Inlining() const
+	{
+		return _ProjectFolderEntry.Inlining() == ProjectFolderEntryInlining::Auto;
+	}
+
+	void ProjectFolderEntryViewModel::Inlining(bool value)
+	{
+		const auto valueAsEnum = value ? ProjectFolderEntryInlining::Auto : ProjectFolderEntryInlining::Never;
+		if (_ProjectFolderEntry.Inlining() != valueAsEnum)
+		{
+			_ProjectFolderEntry.Inlining(valueAsEnum);
+			_NotifyChanges(L"Inlining");
+		}
+	};
+
+	ProjectMatchEntryViewModel::ProjectMatchEntryViewModel(Model::ProjectMatchEntry matchProjectsEntry) :
+		ProjectMatchEntryViewModelT<ProjectMatchEntryViewModel, NewProjectMenuEntryViewModel>(Model::NewProjectMenuEntryType::ProjectMatch),
+		_ProjectMatchEntry{ matchProjectsEntry }
+	{
+	}
+
+	hstring ProjectMatchEntryViewModel::DisplayText() const
+	{
+		std::wstring displayText;
+		if (const auto projectName = _ProjectMatchEntry.Name(); !projectName.empty())
+		{
+			fmt::format_to(std::back_inserter(displayText), FMT_COMPILE(L"project: {}, "), projectName);
+		}
+		if (const auto commandline = _ProjectMatchEntry.Commandline(); !commandline.empty())
+		{
+			fmt::format_to(std::back_inserter(displayText), FMT_COMPILE(L"commandline: {}, "), commandline);
+		}
+		if (const auto source = _ProjectMatchEntry.Source(); !source.empty())
+		{
+			fmt::format_to(std::back_inserter(displayText), FMT_COMPILE(L"source: {}, "), source);
+		}
+
+		// Chop off the last ", "
+		displayText.resize(displayText.size() - 2);
+		return winrt::hstring{ displayText };
+	}
+
+	ProjectRemainingEntryViewModel::ProjectRemainingEntryViewModel(Model::ProjectRemainingEntry remainingProjectsEntry) :
+		ProjectRemainingEntryViewModelT<ProjectRemainingEntryViewModel, NewProjectMenuEntryViewModel>(Model::NewProjectMenuEntryType::ProjectRemaining),
+		_ProjectRemainingEntry{ remainingProjectsEntry }
+	{
+	}
+}

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.h
@@ -49,7 +49,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         // TODO: remove return nullptr
         Windows::Foundation::Collections::IObservableVector<Model::Project> AvailableProjects() const { return nullptr; }
-        Windows::Foundation::Collections::IObservableVector<Editor::ProjectFolderTreeViewEntry> FolderTree() const;
+        Windows::Foundation::Collections::IObservableVector<Editor::ProjectFolderTreeViewEntry> ProjectFolderTree() const;
         Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel> ProjectCurrentView() const;
         VIEW_MODEL_OBSERVABLE_PROPERTY(Editor::ProjectFolderEntryViewModel, CurrentProjectFolder, nullptr);
         VIEW_MODEL_OBSERVABLE_PROPERTY(Editor::ProjectFolderTreeViewEntry, CurrentProjectFolderTreeViewSelectedItem, nullptr);

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.h
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "NewProjectMenuViewModel.g.h"
+#include "ProjectFolderTreeViewEntry.g.h"
+#include "NewProjectMenuEntryViewModel.g.h"
+#include "ProjectEntryViewModel.g.h"
+#include "ProjectActionEntryViewModel.g.h"
+#include "ProjectSeparatorEntryViewModel.g.h"
+#include "ProjectFolderEntryViewModel.g.h"
+#include "ProjectMatchEntryViewModel.g.h"
+#include "ProjectRemainingEntryViewModel.g.h"
+
+//#include "ProjectViewModel.h"
+#include "ViewModelHelpers.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct NewProjectMenuViewModel : NewProjectMenuViewModelT<NewProjectMenuViewModel>, ViewModelHelper<NewProjectMenuViewModel>
+    {
+    public:
+        NewProjectMenuViewModel(Model::CascadiaSettings settings);
+        void UpdateSettings(const Model::CascadiaSettings& settings);
+        void GenerateFolderTree();
+        Windows::Foundation::Collections::IVector<Editor::ProjectFolderEntryViewModel> FindFolderPathByName(const hstring& name);
+
+        bool IsProjectRemainingEntryMissing() const;
+        bool IsProjectFolderView() const noexcept;
+
+        void RequestReorderEntry(const Editor::NewProjectMenuEntryViewModel& vm, bool goingUp);
+        void RequestDeleteEntry(const Editor::NewProjectMenuEntryViewModel& vm);
+        void RequestMoveEntriesToFolder(const Windows::Foundation::Collections::IVector<Editor::NewProjectMenuEntryViewModel>& entries, const Editor::ProjectFolderEntryViewModel& destinationFolder);
+
+        Editor::NewProjectMenuEntryViewModel RequestAddSelectedProjectEntry();
+        Editor::NewProjectMenuEntryViewModel RequestAddProjectSeparatorEntry();
+        Editor::NewProjectMenuEntryViewModel RequestAddProjectFolderEntry();
+        Editor::NewProjectMenuEntryViewModel RequestAddProjectMatcherEntry();
+        Editor::NewProjectMenuEntryViewModel RequestAddProjectRemainingEntry();
+
+        hstring CurrentFolderName() const;
+        void CurrentFolderName(const hstring& value);
+        bool CurrentFolderInlining() const;
+        void CurrentFolderInlining(bool value);
+        bool CurrentFolderAllowEmpty() const;
+        void CurrentFolderAllowEmpty(bool value);
+
+        // TODO: remove return nullptr
+        Windows::Foundation::Collections::IObservableVector<Model::Project> AvailableProjects() const { return nullptr; }
+        Windows::Foundation::Collections::IObservableVector<Editor::ProjectFolderTreeViewEntry> FolderTree() const;
+        Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel> ProjectCurrentView() const;
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Editor::ProjectFolderEntryViewModel, CurrentProjectFolder, nullptr);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Editor::ProjectFolderTreeViewEntry, CurrentProjectFolderTreeViewSelectedItem, nullptr);
+
+        // Bound to the UI to create new entries
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::Project, SelectedProject, nullptr);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(hstring, ProjectMatcherName);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(hstring, ProjectMatcherSource);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(hstring, ProjectMatcherCommandline);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(hstring, AddProjectFolderName);
+
+    private:
+        Model::CascadiaSettings _Settings{ nullptr };
+        Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel> _rootEntries;
+        Windows::Foundation::Collections::IObservableVector<Editor::ProjectFolderTreeViewEntry> _folderTreeCache;
+        Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel>::VectorChanged_revoker _rootEntriesChangedRevoker;
+
+        static bool _IsProjectRemainingEntryMissing(const Windows::Foundation::Collections::IVector<Editor::NewProjectMenuEntryViewModel>& entries);
+        void _FolderPropertyChanged(const IInspectable& sender, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args);
+    };
+
+    struct ProjectFolderTreeViewEntry : ProjectFolderTreeViewEntryT<ProjectFolderTreeViewEntry>
+    {
+    public:
+        ProjectFolderTreeViewEntry(Editor::ProjectFolderEntryViewModel folderEntry);
+
+        hstring Name() const;
+        hstring Icon() const;
+        Editor::ProjectFolderEntryViewModel FolderEntryVM() { return _folderEntry; }
+
+        WINRT_PROPERTY(Windows::Foundation::Collections::IObservableVector<Microsoft::Terminal::Settings::Editor::ProjectFolderTreeViewEntry>, Children);
+
+    private:
+        Editor::ProjectFolderEntryViewModel _folderEntry;
+    };
+
+    struct NewProjectMenuEntryViewModel : NewProjectMenuEntryViewModelT<NewProjectMenuEntryViewModel>, ViewModelHelper<NewProjectMenuEntryViewModel>
+    {
+    public:
+        static Model::NewProjectMenuEntry GetModel(const Editor::NewProjectMenuEntryViewModel& viewModel);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::NewProjectMenuEntryType, Type, Model::NewProjectMenuEntryType::Invalid);
+
+    protected:
+        explicit NewProjectMenuEntryViewModel(const Model::NewProjectMenuEntryType type) noexcept;
+    };
+
+    struct ProjectEntryViewModel : ProjectEntryViewModelT<ProjectEntryViewModel, NewProjectMenuEntryViewModel>
+    {
+    public:
+        ProjectEntryViewModel(Model::ProjectEntry projectEntry);
+
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::ProjectEntry, ProjectEntry, nullptr);
+    };
+
+    struct ProjectActionEntryViewModel : ProjectActionEntryViewModelT<ProjectActionEntryViewModel, NewProjectMenuEntryViewModel>
+    {
+    public:
+        ProjectActionEntryViewModel(Model::ProjectActionEntry actionEntry, Model::CascadiaSettings settings);
+
+        hstring DisplayText() const;
+        hstring Icon() const;
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::ProjectActionEntry, ProjectActionEntry, nullptr);
+
+    private:
+        Model::CascadiaSettings _Settings;
+    };
+
+    struct ProjectSeparatorEntryViewModel : ProjectSeparatorEntryViewModelT<ProjectSeparatorEntryViewModel, NewProjectMenuEntryViewModel>
+    {
+    public:
+        ProjectSeparatorEntryViewModel(Model::ProjectSeparatorEntry separatorEntry);
+
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::ProjectSeparatorEntry, ProjectSeparatorEntry, nullptr);
+    };
+
+    struct ProjectFolderEntryViewModel : ProjectFolderEntryViewModelT<ProjectFolderEntryViewModel, NewProjectMenuEntryViewModel>
+    {
+    public:
+        ProjectFolderEntryViewModel(Model::ProjectFolderEntry folderEntry, Model::CascadiaSettings settings);
+        explicit ProjectFolderEntryViewModel(Model::ProjectFolderEntry folderEntry);
+
+        bool Inlining() const;
+        void Inlining(bool value);
+        GETSET_OBSERVABLE_PROJECTED_SETTING(_ProjectFolderEntry, Name);
+        GETSET_OBSERVABLE_PROJECTED_SETTING(_ProjectFolderEntry, Icon);
+        GETSET_OBSERVABLE_PROJECTED_SETTING(_ProjectFolderEntry, AllowEmpty);
+
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel>, Entries);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::ProjectFolderEntry, ProjectFolderEntry, nullptr);
+
+    private:
+        Windows::Foundation::Collections::IObservableVector<Editor::NewProjectMenuEntryViewModel>::VectorChanged_revoker _entriesChangedRevoker;
+        Model::CascadiaSettings _Settings;
+    };
+
+    struct ProjectMatchEntryViewModel : ProjectMatchEntryViewModelT<ProjectMatchEntryViewModel, NewProjectMenuEntryViewModel>
+    {
+    public:
+        ProjectMatchEntryViewModel(Model::ProjectMatchEntry projectMatchEntry);
+
+        hstring DisplayText() const;
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::ProjectMatchEntry, ProjectMatchEntry, nullptr);
+    };
+
+    struct ProjectRemainingEntryViewModel : ProjectRemainingEntryViewModelT<ProjectRemainingEntryViewModel, NewProjectMenuEntryViewModel>
+    {
+    public:
+        ProjectRemainingEntryViewModel(Model::ProjectRemainingEntry projectRemainingEntry);
+
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Model::ProjectRemainingEntry, ProjectRemainingEntry, nullptr);
+    };
+};
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(NewProjectMenuViewModel);
+    BASIC_FACTORY(ProjectFolderTreeViewEntry);
+    BASIC_FACTORY(ProjectEntryViewModel);
+    BASIC_FACTORY(ProjectActionEntryViewModel);
+    BASIC_FACTORY(ProjectSeparatorEntryViewModel);
+    BASIC_FACTORY(ProjectFolderEntryViewModel);
+    BASIC_FACTORY(ProjectMatchEntryViewModel);
+    BASIC_FACTORY(ProjectRemainingEntryViewModel);
+}

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.idl
@@ -28,9 +28,9 @@ namespace Microsoft.Terminal.Settings.Editor
         ProjectFolderTreeViewEntry CurrentProjectFolderTreeViewSelectedItem;
         Boolean IsProjectRemainingEntryMissing { get; };
 
-        IObservableVector<NewProjectMenuEntryViewModel> CurrentView { get; };
+        IObservableVector<NewProjectMenuEntryViewModel> ProjectCurrentView { get; };
         IObservableVector<Microsoft.Terminal.Settings.Model.Project> AvailableProjects { get; };
-        IObservableVector<ProjectFolderTreeViewEntry> FolderTree { get; };
+        IObservableVector<ProjectFolderTreeViewEntry> ProjectFolderTree { get; };
         Microsoft.Terminal.Settings.Model.Project SelectedProject;
 
         String CurrentFolderName;
@@ -39,7 +39,7 @@ namespace Microsoft.Terminal.Settings.Editor
         String ProjectMatcherName;
         String ProjectMatcherSource;
         String ProjectMatcherCommandline;
-        String AddFolderName;
+        String AddProjectFolderName;
 
         void RequestReorderEntry(NewProjectMenuEntryViewModel vm, Boolean goingUp);
         void RequestDeleteEntry(NewProjectMenuEntryViewModel vm);

--- a/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/NewProjectMenuViewModel.idl
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//import "ProjectViewModel.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    [default_interface] runtimeclass ProjectFolderTreeViewEntry
+    {
+        ProjectFolderTreeViewEntry(ProjectFolderEntryViewModel folderEntry);
+
+        String Name { get; };
+        String Icon { get; };
+        ProjectFolderEntryViewModel FolderEntryVM { get; };
+
+        IObservableVector<Microsoft.Terminal.Settings.Editor.ProjectFolderTreeViewEntry> Children { get; };
+    }
+
+    runtimeclass NewProjectMenuViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        NewProjectMenuViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
+        void UpdateSettings(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
+        void GenerateFolderTree();
+        Windows.Foundation.Collections.IVector<ProjectFolderEntryViewModel> FindFolderPathByName(String name);
+
+        ProjectFolderEntryViewModel CurrentProjectFolder;
+        Boolean IsProjectFolderView { get; };
+        ProjectFolderTreeViewEntry CurrentProjectFolderTreeViewSelectedItem;
+        Boolean IsProjectRemainingEntryMissing { get; };
+
+        IObservableVector<NewProjectMenuEntryViewModel> CurrentView { get; };
+        IObservableVector<Microsoft.Terminal.Settings.Model.Project> AvailableProjects { get; };
+        IObservableVector<ProjectFolderTreeViewEntry> FolderTree { get; };
+        Microsoft.Terminal.Settings.Model.Project SelectedProject;
+
+        String CurrentFolderName;
+        Boolean CurrentFolderInlining;
+        Boolean CurrentFolderAllowEmpty;
+        String ProjectMatcherName;
+        String ProjectMatcherSource;
+        String ProjectMatcherCommandline;
+        String AddFolderName;
+
+        void RequestReorderEntry(NewProjectMenuEntryViewModel vm, Boolean goingUp);
+        void RequestDeleteEntry(NewProjectMenuEntryViewModel vm);
+        void RequestMoveEntriesToFolder(IVector<NewProjectMenuEntryViewModel> entries, ProjectFolderEntryViewModel folderEntry);
+
+        NewProjectMenuEntryViewModel RequestAddSelectedProjectEntry();
+        NewProjectMenuEntryViewModel RequestAddProjectSeparatorEntry();
+        NewProjectMenuEntryViewModel RequestAddProjectFolderEntry();
+        NewProjectMenuEntryViewModel RequestAddProjectMatcherEntry();
+        NewProjectMenuEntryViewModel RequestAddProjectRemainingEntry();
+    }
+
+    [default_interface] unsealed runtimeclass NewProjectMenuEntryViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        Microsoft.Terminal.Settings.Model.NewProjectMenuEntryType Type;
+    }
+
+    [default_interface] runtimeclass ProjectEntryViewModel : Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel
+    {
+        ProjectEntryViewModel(Microsoft.Terminal.Settings.Model.ProjectEntry projectEntry);
+
+        Microsoft.Terminal.Settings.Model.ProjectEntry ProjectEntry { get; };
+    }
+
+    [default_interface] runtimeclass ProjectActionEntryViewModel : Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel
+    {
+        ProjectActionEntryViewModel(Microsoft.Terminal.Settings.Model.ProjectActionEntry actionEntry, Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
+
+        Microsoft.Terminal.Settings.Model.ProjectActionEntry ProjectActionEntry { get; };
+        String DisplayText { get; };
+        String Icon { get; };
+    }
+
+    [default_interface] runtimeclass ProjectSeparatorEntryViewModel : Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel
+    {
+        ProjectSeparatorEntryViewModel(Microsoft.Terminal.Settings.Model.ProjectSeparatorEntry separatorEntry);
+    }
+
+    [default_interface] runtimeclass ProjectFolderEntryViewModel : Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel
+    {
+        ProjectFolderEntryViewModel(Microsoft.Terminal.Settings.Model.ProjectFolderEntry folderEntry, Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
+
+        String Name;
+        String Icon;
+        Boolean Inlining;
+        Boolean AllowEmpty;
+        IObservableVector<Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel> Entries;
+    }
+
+    [default_interface] runtimeclass ProjectMatchEntryViewModel : Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel
+    {
+        ProjectMatchEntryViewModel(Microsoft.Terminal.Settings.Model.ProjectMatchEntry projectMatchEntry);
+
+        String DisplayText { get; };
+    }
+
+    [default_interface] runtimeclass ProjectRemainingEntryViewModel : Microsoft.Terminal.Settings.Editor.NewProjectMenuEntryViewModel
+    {
+        ProjectRemainingEntryViewModel(Microsoft.Terminal.Settings.Model.ProjectRemainingEntry projectRemainingEntry);
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2100,6 +2100,10 @@
     <value>Profile</value>
     <comment>Header for a control that adds a terminal profile to the new tab menu.</comment>
   </data>
+  <data name="NewProjectMenu_AddProject.Header" xml:space="preserve">
+    <value>Project</value>
+    <comment>Header for a control that adds a terminal project to the new projects menu.</comment>
+  </data>
   <data name="NewTabMenu_AddMatchProfiles.Header" xml:space="preserve">
     <value>Profile matcher</value>
     <comment>Header for a control that adds a terminal profile matcher to the new tab menu. This entry adds profiles that match the given parameters.</comment>
@@ -2140,6 +2144,10 @@
     <value>Add profile matcher</value>
     <comment>Label for a button confirming to add the profile matcher to the new tab menu as an entry.</comment>
   </data>
+  <data name="NewProjectMenu_AddProjectMatchTextBlock.Text" xml:space="preserve">
+    <value>Add project matcher</value>
+    <comment>Label for a button confirming to add the project matcher to the new projects menu as an entry.</comment>
+  </data>
   <data name="NewTabMenu_AddFolder_FolderName.PlaceholderText" xml:space="preserve">
     <value>Folder name</value>
     <comment>Placeholder text for a text box control used to set the name of the folder.</comment>
@@ -2148,7 +2156,15 @@
     <value>Delete selected entries</value>
     <comment>Label for a button that can be used to delete any new tab menu entries that are currently selected</comment>
   </data>
+  <data name="NewProjectMenu_DeleteMultipleTextBlock.Text" xml:space="preserve">
+    <value>Delete selected entries</value>
+    <comment>Label for a button that can be used to delete any new tab menu entries that are currently selected</comment>
+  </data>
   <data name="NewTabMenu_MoveToFolderTextBlock.Text" xml:space="preserve">
+    <value>Move selected entries to folder...</value>
+    <comment>Label for a button that can be used to move any new tab menu entries that are currently selected into an existing folder</comment>
+  </data>
+  <data name="NewProjectMenu_MoveToFolderTextBlock.Text" xml:space="preserve">
     <value>Move selected entries to folder...</value>
     <comment>Label for a button that can be used to move any new tab menu entries that are currently selected into an existing folder</comment>
   </data>
@@ -2165,6 +2181,10 @@
     <comment>Text label for the secondary button on the folder picker content dialog. When clicked, the operation of picking a folder is cancelled by the user.</comment>
   </data>
   <data name="NewTabMenu_RootFolderName" xml:space="preserve">
+    <value>&lt;root&gt;</value>
+    <comment>{Locked="&lt;"}{Locked="&gt;"} Text label for the name of the "root" folder. This is used to allow the user to select the root as a destination folder.</comment>
+  </data>
+  <data name="NewProjectMenu_RootFolderName" xml:space="preserve">
     <value>&lt;root&gt;</value>
     <comment>{Locked="&lt;"}{Locked="&gt;"} Text label for the name of the "root" folder. This is used to allow the user to select the root as a destination folder.</comment>
   </data>
@@ -2197,6 +2217,10 @@
     <comment>Additional text displayed near "NewTabMenu_CurrentFolderAllowEmpty.Header".</comment>
   </data>
   <data name="NewTabMenu_ActionNotFound" xml:space="preserve">
+    <value>Action ID not found</value>
+    <comment>Displayed text for an entry who's action identifier wasn't found. The action ID is presented in the format "Action ID not found: &lt;actionID&gt;"</comment>
+  </data>
+  <data name="NewProjectMenu_ActionNotFound" xml:space="preserve">
     <value>Action ID not found</value>
     <comment>Displayed text for an entry who's action identifier wasn't found. The action ID is presented in the format "Action ID not found: &lt;actionID&gt;"</comment>
   </data>
@@ -2236,17 +2260,33 @@
     <value>Add selected profile</value>
     <comment>Tooltip for a button that adds the selected profile to the new tab menu.</comment>
   </data>
+  <data name="NewProjectMenu_AddProjectButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Add selected project</value>
+    <comment>Tooltip for a button that adds the selected project to the new projects menu.</comment>
+  </data>
   <data name="NewTabMenu_AddSeparatorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Add separator</value>
     <comment>Tooltip for a button that adds a separator to the new tab menu.</comment>
+  </data>
+  <data name="NewProjectMenu_AddSeparatorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Add separator</value>
+    <comment>Tooltip for a button that adds a separator to the new projects menu.</comment>
   </data>
   <data name="NewTabMenu_AddFolderButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Add folder</value>
     <comment>Tooltip for a button that adds a folder to the new tab menu.</comment>
   </data>
+  <data name="NewProjectMenu_AddFolderButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Add folder</value>
+    <comment>Tooltip for a button that adds a folder to the new projects menu.</comment>
+  </data>
   <data name="NewTabMenu_AddRemainingProfilesButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Add remaining profiles</value>
     <comment>Tooltip for a button that adds an entry that represents the remaining profiles to the new tab menu.</comment>
+  </data>
+  <data name="NewProjectMenu_AddProjectRemainingButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Add remaining projects</value>
+    <comment>Tooltip for a button that adds an entry that represents the remaining projects to the new projects menu.</comment>
   </data>
   <data name="NewTabMenuEntry_SeparatorItem.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>&lt;Separator&gt;</value>

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -9,6 +9,7 @@
 #include <WtExeUtils.h>
 
 #define ENV_WT_BASE_SETTINGS_PATH L"WT_BASE_SETTINGS_PATH"
+#define ENV_WT_PROJECT_NAME L"WT_PROJECT_NAME"
 
 static constexpr std::wstring_view UnpackagedSettingsFolderName{ L"Microsoft\\Windows Terminal\\" };
 static constexpr std::wstring_view ReleaseSettingsFolder{ L"Packages\\Microsoft.WindowsTerminal_8wekyb3d8bbwe\\LocalState\\" };
@@ -17,95 +18,113 @@ static constexpr std::wstring_view PortableModeSettingsFolder{ L"settings" };
 
 namespace winrt::Microsoft::Terminal::Settings::Model
 {
-    // Returns a path like C:\Users\<username>\AppData\Local\Packages\<packagename>\LocalState
-    // You can put your settings.json or state.json in this directory.
-    bool IsPortableMode()
-    {
-        static auto portableMode = []() {
-            std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
-            modulePath.replace_filename(PortableModeMarkerFile);
-            return std::filesystem::exists(modulePath);
-        }();
-        return portableMode;
-    }
+	// Returns a path like C:\Users\<username>\AppData\Local\Packages\<packagename>\LocalState
+	// You can put your settings.json or state.json in this directory.
+	bool IsPortableMode()
+	{
+		static auto portableMode = []() {
+			std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
+			modulePath.replace_filename(PortableModeMarkerFile);
+			return std::filesystem::exists(modulePath);
+		}();
+		return portableMode;
+	}
 
-    std::filesystem::path GetBaseSettingsPath()
-    {
-        static auto baseSettingsPath = []() {
-            try
-            {
-                std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
-                if (!envSettingsPath.empty())
-                {
-                    std::filesystem::create_directories(envSettingsPath);
-                    return envSettingsPath;
-                }
-            }
-            CATCH_LOG()
+	std::filesystem::path GetBaseSettingsPath()
+	{
+		static auto baseSettingsPath = []() {
+			try
+			{
+				std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+				if (!envSettingsPath.empty())
+				{
+					std::filesystem::create_directories(envSettingsPath);
+					return envSettingsPath;
+				}
+			}
+			CATCH_LOG()
 
-            if (!IsPackaged() && IsPortableMode())
-            {
-                std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
-                modulePath.replace_filename(PortableModeSettingsFolder);
-                std::filesystem::create_directories(modulePath);
-                return modulePath;
-            }
+			std::wstring_view envProjectName{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_PROJECT_NAME) };
 
-            wil::unique_cotaskmem_string localAppDataFolder;
-            // KF_FLAG_FORCE_APP_DATA_REDIRECTION, when engaged, causes SHGet... to return
-            // the new AppModel paths (Packages/xxx/RoamingState, etc.) for standard path requests.
-            // Using this flag allows us to avoid Windows.Storage.ApplicationData completely.
-            THROW_IF_FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_FORCE_APP_DATA_REDIRECTION, nullptr, &localAppDataFolder));
+			if (!IsPackaged() && IsPortableMode())
+			{
+				std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
+				modulePath.replace_filename(PortableModeSettingsFolder);
+				if (!envProjectName.empty())
+				{
+					modulePath /= envProjectName;
+				}
+				std::filesystem::create_directories(modulePath);
+				return modulePath;
+			}
 
-            std::filesystem::path parentDirectoryForSettingsFile{ localAppDataFolder.get() };
+			wil::unique_cotaskmem_string localAppDataFolder;
+			// KF_FLAG_FORCE_APP_DATA_REDIRECTION, when engaged, causes SHGet... to return
+			// the new AppModel paths (Packages/xxx/RoamingState, etc.) for standard path requests.
+			// Using this flag allows us to avoid Windows.Storage.ApplicationData completely.
+			THROW_IF_FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_FORCE_APP_DATA_REDIRECTION, nullptr, &localAppDataFolder));
 
-            if (!IsPackaged())
-            {
-                parentDirectoryForSettingsFile /= UnpackagedSettingsFolderName;
-            }
+			std::filesystem::path parentDirectoryForSettingsFile{ localAppDataFolder.get() };
 
-            // Create the directory if it doesn't exist
-            std::filesystem::create_directories(parentDirectoryForSettingsFile);
+			if (!envProjectName.empty())
+			{
+				parentDirectoryForSettingsFile /= envProjectName;
+			}
 
-            return parentDirectoryForSettingsFile;
-        }();
-        return baseSettingsPath;
-    }
+			if (!IsPackaged())
+			{
+				parentDirectoryForSettingsFile /= UnpackagedSettingsFolderName;
+			}
 
-    // Returns a path like C:\Users\<username>\AppData\Local\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState
-    // to the path of the stable release settings
-    std::filesystem::path GetReleaseSettingsPath()
-    {
-        static std::filesystem::path baseSettingsPath = []() {
-            try
-            {
-                std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
-                if (!envSettingsPath.empty())
-                {
-                    std::filesystem::create_directories(envSettingsPath);
-                    return envSettingsPath;
-                }
-            }
-            CATCH_LOG()
+			// Create the directory if it doesn't exist
+			std::filesystem::create_directories(parentDirectoryForSettingsFile);
 
-            wil::unique_cotaskmem_string localAppDataFolder;
-            // We're using KF_FLAG_NO_PACKAGE_REDIRECTION to ensure that we always get the
-            // user's actual local AppData directory.
-            THROW_IF_FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_NO_PACKAGE_REDIRECTION, nullptr, &localAppDataFolder));
+			return parentDirectoryForSettingsFile;
+		}();
+		return baseSettingsPath;
+	}
 
-            // Returns a path like C:\Users\<username>\AppData\Local
-            std::filesystem::path parentDirectoryForSettingsFile{ localAppDataFolder.get() };
+	// Returns a path like C:\Users\<username>\AppData\Local\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState
+	// to the path of the stable release settings
+	std::filesystem::path GetReleaseSettingsPath()
+	{
+		static std::filesystem::path baseSettingsPath = []() {
+			try
+			{
+				std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+				if (!envSettingsPath.empty())
+				{
+					std::filesystem::create_directories(envSettingsPath);
+					return envSettingsPath;
+				}
+			}
+			CATCH_LOG()
 
-            //Appending \Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState to the settings path
-            parentDirectoryForSettingsFile /= ReleaseSettingsFolder;
+			std::wstring_view envProjectName{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_PROJECT_NAME) };
 
-            if (!IsPackaged())
-            {
-                parentDirectoryForSettingsFile /= UnpackagedSettingsFolderName;
-            }
+			wil::unique_cotaskmem_string localAppDataFolder;
+			// We're using KF_FLAG_NO_PACKAGE_REDIRECTION to ensure that we always get the
+			// user's actual local AppData directory.
+			THROW_IF_FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_NO_PACKAGE_REDIRECTION, nullptr, &localAppDataFolder));
 
-            return parentDirectoryForSettingsFile;
-        }();
-        return baseSettingsPath;
-    }
+			// Returns a path like C:\Users\<username>\AppData\Local
+			std::filesystem::path parentDirectoryForSettingsFile{ localAppDataFolder.get() };
+
+			//Appending \Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState to the settings path
+			parentDirectoryForSettingsFile /= ReleaseSettingsFolder;
+
+			if (!envProjectName.empty())
+			{
+				parentDirectoryForSettingsFile /= envProjectName;
+			}
+
+			if (!IsPackaged())
+			{
+				parentDirectoryForSettingsFile /= UnpackagedSettingsFolderName;
+			}
+
+			return parentDirectoryForSettingsFile;
+		}();
+		return baseSettingsPath;
+	}
 }

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -15,6 +15,7 @@ static constexpr std::wstring_view UnpackagedSettingsFolderName{ L"Microsoft\\Wi
 static constexpr std::wstring_view ReleaseSettingsFolder{ L"Packages\\Microsoft.WindowsTerminal_8wekyb3d8bbwe\\LocalState\\" };
 static constexpr std::wstring_view PortableModeMarkerFile{ L".portable" };
 static constexpr std::wstring_view PortableModeSettingsFolder{ L"settings" };
+static constexpr std::wstring_view ProjectFolderPrefix{ L"Projects" };
 
 namespace winrt::Microsoft::Terminal::Settings::Model
 {
@@ -44,7 +45,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
 			}
 			CATCH_LOG()
 
-			std::wstring_view envProjectName{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_PROJECT_NAME) };
+			std::wstring envProjectName{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_PROJECT_NAME) };
 
 			if (!IsPackaged() && IsPortableMode())
 			{
@@ -52,6 +53,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
 				modulePath.replace_filename(PortableModeSettingsFolder);
 				if (!envProjectName.empty())
 				{
+					modulePath /= ProjectFolderPrefix;
 					modulePath /= envProjectName;
 				}
 				std::filesystem::create_directories(modulePath);
@@ -68,6 +70,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
 
 			if (!envProjectName.empty())
 			{
+				parentDirectoryForSettingsFile /= ProjectFolderPrefix;
 				parentDirectoryForSettingsFile /= envProjectName;
 			}
 
@@ -100,7 +103,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
 			}
 			CATCH_LOG()
 
-			std::wstring_view envProjectName{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_PROJECT_NAME) };
+			std::wstring envProjectName{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_PROJECT_NAME) };
 
 			wil::unique_cotaskmem_string localAppDataFolder;
 			// We're using KF_FLAG_NO_PACKAGE_REDIRECTION to ensure that we always get the
@@ -115,6 +118,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
 
 			if (!envProjectName.empty())
 			{
+				parentDirectoryForSettingsFile /= ProjectFolderPrefix;
 				parentDirectoryForSettingsFile /= envProjectName;
 			}
 

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-d7ec-4107-b7c6-79cb77ae2907}</ProjectGuid>
@@ -46,6 +46,30 @@
     <ClInclude Include="MatchProfilesEntry.h">
       <DependentUpon>NewTabMenuEntry.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="NewProjectMenuEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectSeparatorEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectActionEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectFolderEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectRemainingEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectCollectionEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ProjectMatchEntry.h">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="VisualStudioGenerator.h" />
     <ClInclude Include="DefaultTerminal.h">
       <DependentUpon>DefaultTerminal.idl</DependentUpon>
@@ -92,6 +116,9 @@
     <ClInclude Include="PowershellCoreProfileGenerator.h" />
     <ClInclude Include="Profile.h">
       <DependentUpon>Profile.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="Project.h">
+      <DependentUpon>Project.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="AppearanceConfig.h">
       <DependentUpon>AppearanceConfig.idl</DependentUpon>
@@ -170,6 +197,9 @@
     <ClCompile Include="Profile.cpp">
       <DependentUpon>Profile.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="Project.cpp">
+      <DependentUpon>Project.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="AppearanceConfig.cpp">
       <DependentUpon>AppearanceConfig.idl</DependentUpon>
     </ClCompile>
@@ -206,6 +236,30 @@
     <ClCompile Include="MatchProfilesEntry.cpp">
       <DependentUpon>NewTabMenuEntry.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="NewProjectMenuEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectSeparatorEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectActionEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectFolderEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectCollectionEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectRemainingEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ProjectMatchEntry.cpp">
+      <DependentUpon>NewProjectMenuEntry.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="VsDevCmdGenerator.cpp" />
     <ClCompile Include="VsDevShellGenerator.cpp" />
     <ClCompile Include="VsSetupConfiguration.cpp" />
@@ -221,11 +275,13 @@
     <Midl Include="CascadiaSettings.idl" />
     <Midl Include="ColorScheme.idl" />
     <Midl Include="NewTabMenuEntry.idl" />
+    <Midl Include="NewProjectMenuEntry.idl" />
     <Midl Include="Theme.idl" />
     <Midl Include="Command.idl" />
     <Midl Include="DefaultTerminal.idl" />
     <Midl Include="GlobalAppSettings.idl" />
     <Midl Include="Profile.idl" />
+    <Midl Include="Project.idl" />
     <Midl Include="EnumMappings.idl" />
     <Midl Include="TerminalSettings.idl" />
     <Midl Include="TerminalWarnings.idl" />
@@ -258,7 +314,6 @@
     <ProjectReference Include="$(OpenConsoleDir)src\internal\internal.vcxproj">
       <Project>{ef3e32a7-5ff6-42b4-b6e2-96cd7d033f00}</Project>
     </ProjectReference>
-
     <!-- For whatever reason, we can't include the TerminalControl and
     TerminalSettings projects' winmds via project references. So we'll have to
     manually include the winmds as References below
@@ -271,7 +326,6 @@
 
     We do still need to separately reference the winmds manually below, which is annoying.
     -->
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:true and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -280,7 +334,6 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
   </ItemGroup>
   <ItemGroup>
     <!-- Manually add references to each of our dependent winmds. Mark them as private=false and CopyLocalSatelliteAssemblies=false, so that we don't
@@ -323,7 +376,6 @@
   <!-- ========================= Globals ======================== -->
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <!-- PowerShell version check, outputs error if the wrong version is installed. -->
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
   <Target Name="BeforeResourceCompile" Inputs="defaults.json;userDefaults.json;enableColorSelection.json" Outputs="Generated Files\defaults.json;Generated Files\userDefaults.json;Generated Files\enableColorSelection.json">
@@ -333,5 +385,4 @@
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CompressJson.ps1&quot; -JsonFile userDefaults.json -OutPath &quot;Generated Files\userDefaults.json&quot;" />
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CompressJson.ps1&quot; -JsonFile enableColorSelection.json -OutPath &quot;Generated Files\enableColorSelection.json&quot;" />
   </Target>
-
 </Project>

--- a/src/cascadia/TerminalSettingsModel/NewProjectMenuEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/NewProjectMenuEntry.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "NewProjectMenuEntry.h"
+#include "JsonUtils.h"
+#include "TerminalSettingsSerializationHelpers.h"
+#include "ProjectSeparatorEntry.h"
+#include "ProjectFolderEntry.h"
+#include "ProjectEntry.h"
+#include "ProjectActionEntry.h"
+#include "ProjectRemainingEntry.h"
+#include "ProjectMatchEntry.h"
+
+#include "NewProjectMenuEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+using NewProjectMenuEntryType = winrt::Microsoft::Terminal::Settings::Model::NewProjectMenuEntryType;
+
+static constexpr std::string_view TypeKey{ "type" };
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    NewProjectMenuEntry::NewProjectMenuEntry(const NewProjectMenuEntryType type) noexcept :
+        _Type{ type }
+    {
+    }
+
+    // This method will be overridden by the subclasses, which will then call this
+    // parent implementation for a "base" json object.
+    Json::Value NewProjectMenuEntry::ToJson() const
+    {
+        Json::Value json{ Json::ValueType::objectValue };
+
+        JsonUtils::SetValueForKey(json, TypeKey, _Type);
+
+        return json;
+    }
+
+    // Deserialize the JSON object based on the given type. We use the map from above for that.
+    winrt::com_ptr<NewProjectMenuEntry> NewProjectMenuEntry::FromJson(const Json::Value& json)
+    {
+        const auto type = JsonUtils::GetValueForKey<NewProjectMenuEntryType>(json, TypeKey);
+
+        switch (type)
+        {
+        case NewProjectMenuEntryType::ProjectSeparator:
+            return ProjectSeparatorEntry::FromJson(json);
+        case NewProjectMenuEntryType::ProjectFolder:
+            return ProjectFolderEntry::FromJson(json);
+        case NewProjectMenuEntryType::Project:
+            return ProjectEntry::FromJson(json);
+        case NewProjectMenuEntryType::ProjectRemaining:
+            return ProjectRemainingEntry::FromJson(json);
+        case NewProjectMenuEntryType::ProjectMatch:
+            return ProjectMatchEntry::FromJson(json);
+        case NewProjectMenuEntryType::ProjectAction:
+            return ProjectActionEntry::FromJson(json);
+        default:
+            return nullptr;
+        }
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/NewProjectMenuEntry.h
+++ b/src/cascadia/TerminalSettingsModel/NewProjectMenuEntry.h
@@ -1,0 +1,73 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- NewProjectMenuEntry.h
+
+Abstract:
+- An entry in the "new project" dropdown menu. These entries exist in a few varieties,
+    such as separators, folders, or profile links.
+
+Author(s):
+- Floris Westerman - August 2022
+
+--*/
+#pragma once
+
+#include "NewProjectMenuEntry.g.h"
+#include "JsonUtils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct NewProjectMenuEntry : NewProjectMenuEntryT<NewProjectMenuEntry>
+    {
+    public:
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+        virtual Json::Value ToJson() const;
+        virtual Model::NewProjectMenuEntry Copy() const = 0;
+
+        WINRT_PROPERTY(NewProjectMenuEntryType, Type, NewProjectMenuEntryType::Invalid);
+
+        // We have a protected/hidden constructor so consumers cannot instantiate
+        // this base class directly and need to go through either FromJson
+        // or one of the subclasses.
+    protected:
+        explicit NewProjectMenuEntry(const NewProjectMenuEntryType type) noexcept;
+    };
+}
+
+namespace Microsoft::Terminal::Settings::Model::JsonUtils
+{
+    using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+    template<>
+    struct ConversionTrait<NewProjectMenuEntry>
+    {
+        NewProjectMenuEntry FromJson(const Json::Value& json)
+        {
+            const auto entry = implementation::NewProjectMenuEntry::FromJson(json);
+            if (entry == nullptr)
+            {
+                return nullptr;
+            }
+
+            return *entry;
+        }
+
+        bool CanConvert(const Json::Value& json) const
+        {
+            return json.isObject();
+        }
+
+        Json::Value ToJson(const NewProjectMenuEntry& val)
+        {
+            return winrt::get_self<implementation::NewProjectMenuEntry>(val)->ToJson();
+        }
+
+        std::string TypeDescription() const
+        {
+            return "NewProjectMenuEntry";
+        }
+    };
+}

--- a/src/cascadia/TerminalSettingsModel/NewProjectMenuEntry.idl
+++ b/src/cascadia/TerminalSettingsModel/NewProjectMenuEntry.idl
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "Project.idl";
+
+namespace Microsoft.Terminal.Settings.Model
+{
+    enum NewProjectMenuEntryType
+    {
+        Invalid = 0,
+        Project,
+        ProjectSeparator,
+        ProjectFolder,
+        ProjectRemaining,
+        ProjectMatch,
+        ProjectAction
+    };
+
+    [default_interface] unsealed runtimeclass NewProjectMenuEntry
+    {
+        NewProjectMenuEntryType Type;
+    }
+
+    [default_interface] runtimeclass ProjectSeparatorEntry : NewProjectMenuEntry
+    {
+        ProjectSeparatorEntry();
+    }
+
+    [default_interface] runtimeclass ProjectEntry : NewProjectMenuEntry
+    {
+        ProjectEntry();
+        ProjectEntry(String project);
+
+        Project Project;
+        Int32 ProjectIndex;
+        String Icon;
+    }
+
+    [default_interface] runtimeclass ProjectActionEntry : NewProjectMenuEntry
+    {
+        ProjectActionEntry();
+
+        String ActionId;
+        String Icon;
+    }
+
+    enum ProjectFolderEntryInlining
+    {
+        Never = 0,
+        Auto
+    };
+
+    [default_interface] runtimeclass ProjectFolderEntry : NewProjectMenuEntry
+    {
+        ProjectFolderEntry();
+        ProjectFolderEntry(String name);
+
+        String Name;
+        String Icon;
+        ProjectFolderEntryInlining Inlining;
+        Boolean AllowEmpty;
+
+        IVector<NewProjectMenuEntry> Entries();
+        IVector<NewProjectMenuEntry> RawEntries;
+    }
+
+    [default_interface] unsealed runtimeclass ProjectCollectionEntry : NewProjectMenuEntry
+    {
+        IMap<Int32, Project> Projects;
+    }
+
+    [default_interface] runtimeclass ProjectRemainingEntry : ProjectCollectionEntry
+    {
+        ProjectRemainingEntry();
+    }
+
+    [default_interface] runtimeclass ProjectMatchEntry : ProjectCollectionEntry
+    {
+        ProjectMatchEntry();
+
+        String Name;
+        String Commandline;
+        String Source;
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/Project.cpp
+++ b/src/cascadia/TerminalSettingsModel/Project.cpp
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Project.h"
+#include "JsonUtils.h"
+#include "../../types/inc/Utils.hpp"
+
+#include "TerminalSettingsSerializationHelpers.h"
+#include "AppearanceConfig.h"
+#include "FontConfig.h"
+
+#include "Project.g.cpp"
+
+#include <shellapi.h>
+
+using namespace Microsoft::Terminal::Settings::Model;
+using namespace winrt::Microsoft::Terminal::Settings::Model::implementation;
+using namespace winrt::Microsoft::Terminal::Control;
+using namespace winrt::Windows::UI;
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::Foundation;
+using namespace ::Microsoft::Console;
+
+static constexpr std::string_view UpdatesKey{ "updates" };
+static constexpr std::string_view NameKey{ "name" };
+static constexpr std::string_view GuidKey{ "guid" };
+static constexpr std::string_view SourceKey{ "source" };
+static constexpr std::string_view HiddenKey{ "hidden" };
+static constexpr std::string_view IconKey{ "icon" };
+
+Project::Project(guid guid) noexcept :
+	_Guid(guid)
+{
+}
+
+winrt::com_ptr<Project> Project::CopySettings() const
+{
+	const auto project = winrt::make_self<Project>();
+	const auto weakProject = winrt::make_weak<Model::Project>(*project);
+
+	project->_Deleted = _Deleted;
+	project->_Orphaned = _Orphaned;
+	project->_Updates = _Updates;
+	project->_Guid = _Guid;
+	project->_Name = _Name;
+	project->_Source = _Source;
+	project->_Hidden = _Hidden;
+	project->_Icon = _Icon;
+	project->_Origin = _Origin;
+
+#define PROJECT_SETTINGS_COPY(type, name, jsonKey, ...) \
+	project->_##name = _##name;
+#undef PROJECT_SETTINGS_COPY
+
+	return project;
+}
+
+// Method Description:
+// - Create a new instance of this class from a serialized JsonObject.
+// Arguments:
+// - json: an object which should be a serialization of a Project object.
+// Return Value:
+// - a new Project instance created from the values in `json`
+winrt::com_ptr<winrt::Microsoft::Terminal::Settings::Model::implementation::Project> Project::FromJson(const Json::Value& json)
+{
+	auto result = winrt::make_self<Project>();
+	result->LayerJson(json);
+	return result;
+}
+
+// Method Description:
+// - Layer values from the given json object on top of the existing properties
+//   of this object. For any keys we're expecting to be able to parse in the
+//   given object, we'll parse them and replace our settings with values from
+//   the new json object. Properties that _aren't_ in the json object will _not_
+//   be replaced.
+// - Optional values in the project that are set to `null` in the json object
+//   will be set to nullopt.
+// Arguments:
+// - json: an object which should be a partial serialization of a Project object.
+// Return Value:
+// <none>
+void Project::LayerJson(const Json::Value& json)
+{
+	// Project-specific Settings
+	JsonUtils::GetValueForKey(json, NameKey, _Name);
+	JsonUtils::GetValueForKey(json, UpdatesKey, _Updates);
+	JsonUtils::GetValueForKey(json, GuidKey, _Guid);
+
+	// Make sure Source is before Hidden! We use that to exclude false positives from the settings logger!
+	JsonUtils::GetValueForKey(json, SourceKey, _Source);
+	JsonUtils::GetValueForKey(json, HiddenKey, _Hidden);
+	JsonUtils::GetValueForKey(json, IconKey, _Icon);
+
+
+#define PROJECT_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
+	JsonUtils::GetValueForKey(json, jsonKey, _##name);
+
+#undef PROJECT_SETTINGS_LAYER_JSON
+
+}
+
+void Project::_FinalizeInheritance()
+{
+}
+
+// Function Description:
+// - Generates a unique guid for a project, given the name. For an given name, will always return the same GUID.
+// Arguments:
+// - name: The name to generate a unique GUID from
+// Return Value:
+// - a uuidv5 GUID generated from the given name.
+winrt::guid Project::_GenerateGuidForProject(const std::wstring_view& name, const std::wstring_view& source) noexcept
+{
+	// If we have a _source, then we can from a dynamic project generator. Use
+	// our source to build the namespace guid, instead of using the default GUID.
+
+	const auto namespaceGuid = !source.empty() ?
+								   Utils::CreateV5Uuid(RUNTIME_GENERATED_PROJECT_NAMESPACE_GUID, std::as_bytes(std::span{ source })) :
+								   RUNTIME_GENERATED_PROJECT_NAMESPACE_GUID;
+
+	// Always use the name to generate the temporary GUID. That way, across
+	// reloads, we'll generate the same static GUID.
+	return { Utils::CreateV5Uuid(namespaceGuid, std::as_bytes(std::span{ name })) };
+}
+
+// Method Description:
+// - Create a new serialized JsonObject from an instance of this class
+// Arguments:
+// - <none>
+// Return Value:
+// - the JsonObject representing this instance
+Json::Value Project::ToJson() const
+{
+	// Initialize the json with the appearance settings
+	Json::Value json{ Json::ValueType::objectValue };
+
+	// GH #9962:
+	//   If the settings.json was missing, when we load the dynamic projects, they are completely empty.
+	//   This caused us to serialize empty projects "{}" on accident.
+	const auto writeBasicSettings{ !Source().empty() };
+
+	// Project-specific Settings
+	JsonUtils::SetValueForKey(json, NameKey, writeBasicSettings ? Name() : _Name);
+	JsonUtils::SetValueForKey(json, GuidKey, writeBasicSettings ? Guid() : _Guid);
+	JsonUtils::SetValueForKey(json, HiddenKey, writeBasicSettings ? Hidden() : _Hidden);
+	JsonUtils::SetValueForKey(json, SourceKey, writeBasicSettings ? Source() : _Source);
+
+	// Recall: Icon isn't actually a setting in the MTSM_PROJECT_SETTINGS. We
+	// defined it manually in Project, so make sure we only serialize the Icon
+	// if the user actually changed it here.
+	JsonUtils::SetValueForKey(json, IconKey, _Icon);
+
+#define PROJECT_SETTINGS_TO_JSON(type, name, jsonKey, ...) \
+	JsonUtils::SetValueForKey(json, jsonKey, _##name);
+
+#undef PROJECT_SETTINGS_TO_JSON
+
+	return json;
+}
+
+// This is the implementation for and INHERITABLE_SETTING, but with one addition
+// in the setter. We want to make sure to clear out our cached icon, so that we
+// can re-evaluate it as it changes in the SUI.
+void Project::Icon(const winrt::hstring& value)
+{
+	_evaluatedIcon = std::nullopt;
+	_Icon = value;
+}
+winrt::hstring Project::Icon() const
+{
+	const auto val{ _getIconImpl() };
+	return val ? *val : hstring{ L"\uE756" };
+}
+
+winrt::hstring Project::EvaluatedIcon()
+{
+	// We cache the result here, so we don't search the path for the exe every time.
+	if (!_evaluatedIcon.has_value())
+	{
+		_evaluatedIcon = _evaluateIcon();
+	}
+	return *_evaluatedIcon;
+}
+
+winrt::hstring Project::_evaluateIcon() const
+{
+	// If the project has an icon, return it.
+	if (!Icon().empty())
+	{
+		return Icon();
+	}
+
+	return hstring{ L"\uE756" };
+}
+
+bool Project::HasIcon() const
+{
+	return _Icon.has_value();
+}
+
+winrt::Microsoft::Terminal::Settings::Model::Project Project::IconOverrideSource()
+{
+	for (const auto& parent : _parents)
+	{
+		if (auto source{ parent->_getIconOverrideSourceImpl() })
+		{
+			return source;
+		}
+	}
+	return nullptr;
+}
+
+void Project::ClearIcon()
+{
+	_Icon = std::nullopt;
+	_evaluatedIcon = std::nullopt;
+}
+
+std::optional<winrt::hstring> Project::_getIconImpl() const
+{
+	if (_Icon)
+	{
+		return _Icon;
+	}
+	for (const auto& parent : _parents)
+	{
+		if (auto val{ parent->_getIconImpl() })
+		{
+			return val;
+		}
+	}
+	return std::nullopt;
+}
+
+winrt::Microsoft::Terminal::Settings::Model::Project Project::_getIconOverrideSourceImpl() const
+{
+	if (_Icon)
+	{
+		return *this;
+	}
+	for (const auto& parent : _parents)
+	{
+		if (auto source{ parent->_getIconOverrideSourceImpl() })
+		{
+			return source;
+		}
+	}
+	return nullptr;
+}
+
+void Project::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const
+{
+	for (const auto& setting : _changeLog)
+	{
+		changes.emplace(fmt::format(FMT_COMPILE("{}.{}"), context, setting));
+	}
+}

--- a/src/cascadia/TerminalSettingsModel/Project.h
+++ b/src/cascadia/TerminalSettingsModel/Project.h
@@ -1,0 +1,145 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- Project.hpp
+
+Abstract:
+- A Project acts as a single set of terminal settings. Many tabs or panes could
+  exist side-by-side with different Projects simultaneously.
+- Projects could also specify their appearance when unfocused, this is what
+  the inheritance tree looks like for unfocused settings:
+
+				+-------------------+
+				|                   |
+				|Project.defaults   |
+				|                   |
+				|DefaultAppearance  |
+				|                   |
+				+-------------------+
+				   ^             ^
+				   |             |
++------------------++           ++------------------+
+|                   |           |                   |
+|MyProject          |           |Project.defaults   |
+|                   |           |                   |
+|DefaultAppearance  |           |UnfocusedAppearance|
+|                   |           |                   |
++-------------------+           +-------------------+
+				   ^
+				   |
++------------------++
+|                   |
+|MyProject          |
+|                   |
+|UnfocusedAppearance|
+|                   |
++-------------------+
+
+
+Author(s):
+- Mike Griese - March 2019
+
+--*/
+#pragma once
+
+#include "Project.g.h"
+#include "IInheritable.h"
+#include "MTSMSettings.h"
+
+#include "JsonUtils.h"
+#include <DefaultSettings.h>
+#include "AppearanceConfig.h"
+#include "FontConfig.h"
+
+// fwdecl unittest classes
+namespace SettingsModelUnitTests
+{
+	class DeserializationTests;
+	class ProjectTests;
+	class ColorSchemeTests;
+	class KeyBindingsTests;
+};
+namespace TerminalAppUnitTests
+{
+	class DynamicProjectTests;
+	class JsonTests;
+};
+
+using IEnvironmentVariableMap = winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::hstring>;
+
+// GUID used for generating GUIDs at runtime, for Projects that did not have a
+// GUID specified manually.
+constexpr GUID RUNTIME_GENERATED_PROJECT_NAMESPACE_GUID = { 0x42439e5, 0x628d, 0x462b, { 0x84, 0xe1, 0xc, 0xd5, 0x42, 0x5c, 0xa6, 0x13 } };
+;
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+	struct Project : ProjectT<Project>, IInheritable<Project>
+	{
+	public:
+		Project() noexcept = default;
+		Project(guid guid) noexcept;
+
+		hstring ToString()
+		{
+			return Name();
+		}
+		winrt::com_ptr<Project> CopySettings() const;
+
+		static com_ptr<Project> FromJson(const Json::Value& json);
+		void LayerJson(const Json::Value& json);
+
+		Json::Value ToJson() const;
+
+		void _FinalizeInheritance() override;
+
+		void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
+
+		// EvaluatedIcon depends on Icon. It allows us to grab the
+		//   icon from an exe path.
+		// As a result, we can't use the INHERITABLE_SETTING macro for Icon,
+		//   as we manually have to set/unset _evaluatedIcon when Icon changes.
+		winrt::hstring EvaluatedIcon();
+		hstring Icon() const;
+		void Icon(const hstring& value);
+		bool HasIcon() const;
+		Model::Project IconOverrideSource();
+		void ClearIcon();
+
+		WINRT_PROPERTY(bool, Deleted, false);
+		WINRT_PROPERTY(bool, Orphaned, false);
+		WINRT_PROPERTY(OriginTag, Origin, OriginTag::None);
+		WINRT_PROPERTY(guid, Updates);
+
+		// Nullable/optional settings
+
+		// Settings that cannot be put in the macro because of how they are handled in ToJson/LayerJson
+		INHERITABLE_SETTING(Model::Project, hstring, Name, L"Default");
+		INHERITABLE_SETTING(Model::Project, hstring, Source);
+		INHERITABLE_SETTING(Model::Project, bool, Hidden, false);
+		INHERITABLE_SETTING(Model::Project, guid, Guid, _GenerateGuidForProject(Name(), Source()));
+
+	public:
+#define PROJECT_SETTINGS_INITIALIZE(type, name, jsonKey, ...) \
+	INHERITABLE_SETTING_WITH_LOGGING(Model::Project, type, name, jsonKey, ##__VA_ARGS__)
+#undef PROJECT_SETTINGS_INITIALIZE
+
+	private:
+		std::optional<hstring> _Icon{ std::nullopt };
+		std::optional<winrt::hstring> _evaluatedIcon{ std::nullopt };
+		std::set<std::string> _changeLog;
+
+		static guid _GenerateGuidForProject(const std::wstring_view& name, const std::wstring_view& source) noexcept;
+
+		winrt::hstring _evaluateIcon() const;
+		std::optional<hstring> _getIconImpl() const;
+		Model::Project _getIconOverrideSourceImpl() const;
+	};
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+	BASIC_FACTORY(Project);
+}

--- a/src/cascadia/TerminalSettingsModel/Project.idl
+++ b/src/cascadia/TerminalSettingsModel/Project.idl
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "IAppearanceConfig.idl";
+import "ISettingsModelObject.idl";
+import "FontConfig.idl";
+#include "IInheritable.idl.h"
+
+#define INHERITABLE_PROJECT_SETTING(Type, Name) \
+    _BASE_INHERITABLE_SETTING(Type, Name);      \
+    Microsoft.Terminal.Settings.Model.Project Name##OverrideSource { get; }
+
+#define COMMA ,
+
+namespace Microsoft.Terminal.Settings.Model
+{
+    [default_interface] runtimeclass Project : Windows.Foundation.IStringable, ISettingsModelObject {
+        Project();
+        Project(Guid guid);
+
+        // True if the user explicitly removed this Project from settings.json.
+        Boolean Deleted { get; };
+        // True if the user *kept* this Project, but it disappeared from the system.
+        Boolean Orphaned { get; };
+
+        // Helper for magically using a commandline for an icon for a Project
+        // without an explicit icon.
+        String EvaluatedIcon { get; };
+
+        INHERITABLE_PROJECT_SETTING(Guid, Guid);
+        INHERITABLE_PROJECT_SETTING(String, Name);
+        INHERITABLE_PROJECT_SETTING(String, Source);
+        INHERITABLE_PROJECT_SETTING(Boolean, Hidden);
+        INHERITABLE_PROJECT_SETTING(String, Icon);
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectActionEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectActionEntry.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectActionEntry.h"
+#include "JsonUtils.h"
+
+#include "ProjectActionEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+
+static constexpr std::string_view ActionIdKey{ "id" };
+static constexpr std::string_view IconKey{ "icon" };
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+
+    ProjectActionEntry::ProjectActionEntry() noexcept :
+        ProjectActionEntryT<ProjectActionEntry, NewProjectMenuEntry>(NewProjectMenuEntryType::ProjectAction)
+    {
+    }
+
+    Json::Value ProjectActionEntry::ToJson() const
+    {
+        auto json = NewProjectMenuEntry::ToJson();
+
+        JsonUtils::SetValueForKey(json, ActionIdKey, _ActionId);
+        JsonUtils::SetValueForKey(json, IconKey, _Icon);
+
+        return json;
+    }
+
+    winrt::com_ptr<NewProjectMenuEntry> ProjectActionEntry::FromJson(const Json::Value& json)
+    {
+        auto entry = winrt::make_self<ProjectActionEntry>();
+
+        JsonUtils::GetValueForKey(json, ActionIdKey, entry->_ActionId);
+        JsonUtils::GetValueForKey(json, IconKey, entry->_Icon);
+
+        return entry;
+    }
+
+    Model::NewProjectMenuEntry ProjectActionEntry::Copy() const
+    {
+        auto entry = winrt::make_self<ProjectActionEntry>();
+        entry->_ActionId = _ActionId;
+        entry->_Icon = _Icon;
+        return *entry;
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectActionEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectActionEntry.h
@@ -1,0 +1,40 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- ActionEntry.h
+
+Abstract:
+- An action entry in the "new tab" dropdown menu
+
+Author(s):
+- Pankaj Bhojwani - May 2024
+
+--*/
+#pragma once
+
+#include "NewProjectMenuEntry.h"
+#include "ProjectActionEntry.g.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectActionEntry : ProjectActionEntryT<ProjectActionEntry, NewProjectMenuEntry>
+    {
+    public:
+        ProjectActionEntry() noexcept;
+
+        Model::NewProjectMenuEntry Copy() const;
+
+        Json::Value ToJson() const override;
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+
+        WINRT_PROPERTY(winrt::hstring, ActionId);
+        WINRT_PROPERTY(winrt::hstring, Icon);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProjectActionEntry);
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectCollectionEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectCollectionEntry.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectCollectionEntry.h"
+#include "JsonUtils.h"
+
+#include "ProjectCollectionEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+using namespace winrt::Microsoft::Terminal::Settings::Model::implementation;
+
+ProjectCollectionEntry::ProjectCollectionEntry(const NewProjectMenuEntryType type) noexcept :
+    ProjectCollectionEntryT<ProjectCollectionEntry, NewProjectMenuEntry>(type)
+{
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectCollectionEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectCollectionEntry.h
@@ -1,0 +1,39 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- SeparatorEntry.h
+
+Abstract:
+- An entry in the "new tab" dropdown menu that represents some collection
+    of profiles. This is an abstract class that has concretizations like
+    "all profiles from a source" or "all remaining profiles"
+
+Author(s):
+- Floris Westerman - August 2022
+
+--*/
+#pragma once
+
+#include "NewProjectMenuEntry.h"
+#include "ProjectCollectionEntry.g.h"
+#include "Project.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectCollectionEntry : ProjectCollectionEntryT<ProjectCollectionEntry, NewProjectMenuEntry>
+    {
+    public:
+        // Since a comma does not work very nicely in a macro and we need one
+        // for our map definition, we use a macro te define a comma.
+#define COMMA ,
+        WINRT_PROPERTY(winrt::Windows::Foundation::Collections::IMap<int COMMA Model::Project>, Projects);
+#undef COMMA
+
+        // We have a protected/hidden constructor so consumers cannot instantiate
+        // this class directly and need to go through one of the subclasses.
+    protected:
+        explicit ProjectCollectionEntry(const NewProjectMenuEntryType type) noexcept;
+    };
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectEntry.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectEntry.h"
+#include "JsonUtils.h"
+
+#include "ProjectEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+
+static constexpr std::string_view ProjectKey{ "project" };
+static constexpr std::string_view IconKey{ "icon" };
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    ProjectEntry::ProjectEntry() noexcept :
+        ProjectEntry{ winrt::hstring{} }
+    {
+    }
+
+    ProjectEntry::ProjectEntry(const winrt::hstring& project) noexcept :
+        ProjectEntryT<ProjectEntry, NewProjectMenuEntry>(NewProjectMenuEntryType::Project),
+        _ProjectName{ project }
+    {
+    }
+
+    Json::Value ProjectEntry::ToJson() const
+    {
+        auto json = NewProjectMenuEntry::ToJson();
+
+        // We will now return a project reference to the JSON representation. Logic is
+        // as follows:
+        // - When Project is null, this is typically because an existing project menu entry
+        //   in the JSON config is invalid (nonexistent or hidden project). Then, we store
+        //   the original project string value as read from JSON, to improve portability
+        //   of the settings file and limit modifications to the JSON.
+        // - Otherwise, we always store the GUID of the project. This will effectively convert
+        //   all name-matched projects from the settings file to GUIDs. This might be unexpected
+        //   to some users, but is less error-prone and will continue to work when project
+        //   names are changed.
+        if (_Project == nullptr)
+        {
+            JsonUtils::SetValueForKey(json, ProjectKey, _ProjectName);
+        }
+        else
+        {
+            JsonUtils::SetValueForKey(json, ProjectKey, _Project.Guid());
+        }
+        JsonUtils::SetValueForKey(json, IconKey, _Icon);
+
+        return json;
+    }
+
+    winrt::com_ptr<NewProjectMenuEntry> ProjectEntry::FromJson(const Json::Value& json)
+    {
+        auto entry = winrt::make_self<ProjectEntry>();
+
+        JsonUtils::GetValueForKey(json, ProjectKey, entry->_ProjectName);
+        JsonUtils::GetValueForKey(json, IconKey, entry->_Icon);
+
+        return entry;
+    }
+
+    Model::NewProjectMenuEntry ProjectEntry::Copy() const
+    {
+        auto entry{ winrt::make_self<ProjectEntry>() };
+        entry->_Project = _Project;
+        entry->_ProjectIndex = _ProjectIndex;
+        entry->_ProjectName = _ProjectName;
+        entry->_Icon = _Icon;
+        return *entry;
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectEntry.h
@@ -1,0 +1,56 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- FolderEntry.h
+
+Abstract:
+- A profile entry in the "new tab" dropdown menu, referring to
+    a single profile.
+
+Author(s):
+- Floris Westerman - August 2022
+
+--*/
+#pragma once
+
+#include "NewProjectMenuEntry.h"
+#include "ProjectEntry.g.h"
+
+#include "Project.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectEntry : ProjectEntryT<ProjectEntry, NewProjectMenuEntry>
+    {
+    public:
+        ProjectEntry() noexcept;
+        explicit ProjectEntry(const winrt::hstring& project) noexcept;
+
+        Model::NewProjectMenuEntry Copy() const override;
+
+        Json::Value ToJson() const override;
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+
+        // In JSON, only a profile name (guid or string) can be set;
+        // but the consumers of this class would like to have direct access
+        // to the appropriate Model::Profile. Therefore, we have a read-only
+        // property ProfileName that corresponds to the JSON value, and
+        // then CascadiaSettings::_resolveNewTabMenuProfiles() will populate
+        // the Profile and ProfileIndex properties appropriately
+        winrt::hstring ProjectName() const noexcept { return _ProjectName; };
+
+        WINRT_PROPERTY(Model::Project, Project);
+        WINRT_PROPERTY(int, ProjectIndex);
+        WINRT_PROPERTY(winrt::hstring, Icon);
+
+    private:
+        winrt::hstring _ProjectName;
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProjectEntry);
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectFolderEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectFolderEntry.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectFolderEntry.h"
+#include "JsonUtils.h"
+#include "TerminalSettingsSerializationHelpers.h"
+
+#include "ProjectFolderEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+using namespace winrt::Windows::Foundation::Collections;
+
+static constexpr std::string_view NameKey{ "name" };
+static constexpr std::string_view IconKey{ "icon" };
+static constexpr std::string_view EntriesKey{ "entries" };
+static constexpr std::string_view InliningKey{ "inline" };
+static constexpr std::string_view AllowEmptyKey{ "allowEmpty" };
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    ProjectFolderEntry::ProjectFolderEntry() noexcept :
+        ProjectFolderEntry{ winrt::hstring{} }
+    {
+    }
+
+    ProjectFolderEntry::ProjectFolderEntry(const winrt::hstring& name) noexcept :
+        ProjectFolderEntryT<ProjectFolderEntry, NewProjectMenuEntry>(NewProjectMenuEntryType::ProjectFolder),
+        _Name{ name }
+    {
+    }
+
+    Json::Value ProjectFolderEntry::ToJson() const
+    {
+        auto json = NewProjectMenuEntry::ToJson();
+
+        JsonUtils::SetValueForKey(json, NameKey, _Name);
+        JsonUtils::SetValueForKey(json, IconKey, _Icon);
+        JsonUtils::SetValueForKey(json, EntriesKey, _RawEntries);
+        JsonUtils::SetValueForKey(json, InliningKey, _Inlining);
+        JsonUtils::SetValueForKey(json, AllowEmptyKey, _AllowEmpty);
+
+        return json;
+    }
+
+    winrt::com_ptr<NewProjectMenuEntry> ProjectFolderEntry::FromJson(const Json::Value& json)
+    {
+        auto entry = winrt::make_self<ProjectFolderEntry>();
+
+        JsonUtils::GetValueForKey(json, NameKey, entry->_Name);
+        JsonUtils::GetValueForKey(json, IconKey, entry->_Icon);
+        JsonUtils::GetValueForKey(json, EntriesKey, entry->_RawEntries);
+        JsonUtils::GetValueForKey(json, InliningKey, entry->_Inlining);
+        JsonUtils::GetValueForKey(json, AllowEmptyKey, entry->_AllowEmpty);
+
+        return entry;
+    }
+
+    // A FolderEntry should only expose the entries to actually render to WinRT,
+    // to keep the logic for collapsing/expanding more centralised.
+    IVector<Model::NewProjectMenuEntry> ProjectFolderEntry::Entries() const
+    {
+        // We filter the full list of entries from JSON to just include the
+        // non-empty ones.
+        IVector<Model::NewProjectMenuEntry> result{ winrt::single_threaded_vector<Model::NewProjectMenuEntry>() };
+        if (_RawEntries == nullptr)
+        {
+            return result;
+        }
+
+        for (const auto& entry : _RawEntries)
+        {
+            if (entry == nullptr)
+            {
+                continue;
+            }
+
+            switch (entry.Type())
+            {
+            case NewProjectMenuEntryType::Invalid:
+                continue;
+
+            // A profile is filtered out if it is not valid, so if it was not resolved
+            case NewProjectMenuEntryType::Project:
+            {
+                const auto projectEntry = entry.as<Model::ProjectEntry>();
+                if (projectEntry.Project() == nullptr)
+                {
+                    continue;
+                }
+                break;
+            }
+
+            // Any profile collection is filtered out if there are no results
+            case NewProjectMenuEntryType::ProjectRemaining:
+            case NewProjectMenuEntryType::ProjectMatch:
+            {
+                const auto projectCollectionEntry = entry.as<Model::ProjectCollectionEntry>();
+                if (projectCollectionEntry.Projects().Size() == 0)
+                {
+                    continue;
+                }
+                break;
+            }
+
+            // A folder is filtered out if it has an effective size of 0 (calling
+            // this filtering method recursively), and if it is not allowed to be
+            // empty, or if it should auto-inline.
+            case NewProjectMenuEntryType::ProjectFolder:
+            {
+                const auto folderEntry = entry.as<Model::ProjectFolderEntry>();
+                if (folderEntry.Entries().Size() == 0 && (!folderEntry.AllowEmpty() || folderEntry.Inlining() == ProjectFolderEntryInlining::Auto))
+                {
+                    continue;
+                }
+                break;
+            }
+            }
+
+            result.Append(entry);
+        }
+
+        return result;
+    }
+
+    Model::NewProjectMenuEntry ProjectFolderEntry::Copy() const
+    {
+        auto entry = winrt::make_self<ProjectFolderEntry>();
+        entry->_Name = _Name;
+        entry->_Icon = _Icon;
+        entry->_Inlining = _Inlining;
+        entry->_AllowEmpty = _AllowEmpty;
+
+        if (_RawEntries)
+        {
+            entry->_RawEntries = winrt::single_threaded_vector<Model::NewProjectMenuEntry>();
+            for (const auto& e : _RawEntries)
+            {
+                entry->_RawEntries.Append(get_self<NewProjectMenuEntry>(e)->Copy());
+            }
+        }
+        return *entry;
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectFolderEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectFolderEntry.h
@@ -1,0 +1,51 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- FolderEntry.h
+
+Abstract:
+- A folder entry in the "new tab" dropdown menu,
+
+Author(s):
+- Floris Westerman - August 2022
+
+--*/
+#pragma once
+
+#include "pch.h"
+#include "NewProjectMenuEntry.h"
+#include "ProjectFolderEntry.g.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectFolderEntry : ProjectFolderEntryT<ProjectFolderEntry, NewProjectMenuEntry>
+    {
+    public:
+        ProjectFolderEntry() noexcept;
+        explicit ProjectFolderEntry(const winrt::hstring& name) noexcept;
+
+        Model::NewProjectMenuEntry Copy() const override;
+
+        Json::Value ToJson() const override;
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+
+        // In JSON, we can set arbitrarily many profiles or nested profiles, that might not all
+        // be rendered; for example, when a profile entry is invalid, or when a folder is empty.
+        // Therefore, we will store the JSON entries list internally, and then expose only the
+        // entries to be rendered to WinRT.
+        winrt::Windows::Foundation::Collections::IVector<Model::NewProjectMenuEntry> Entries() const;
+
+        WINRT_PROPERTY(winrt::hstring, Name);
+        WINRT_PROPERTY(winrt::hstring, Icon);
+        WINRT_PROPERTY(ProjectFolderEntryInlining, Inlining, ProjectFolderEntryInlining::Never);
+        WINRT_PROPERTY(bool, AllowEmpty, false);
+        WINRT_PROPERTY(winrt::Windows::Foundation::Collections::IVector<Model::NewProjectMenuEntry>, RawEntries);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProjectFolderEntry);
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectMatchEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectMatchEntry.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectMatchEntry.h"
+#include "JsonUtils.h"
+
+#include "ProjectMatchEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+
+static constexpr std::string_view NameKey{ "name" };
+static constexpr std::string_view CommandlineKey{ "commandline" };
+static constexpr std::string_view SourceKey{ "source" };
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    ProjectMatchEntry::ProjectMatchEntry() noexcept :
+        ProjectMatchEntryT<ProjectMatchEntry, ProjectCollectionEntry>(NewProjectMenuEntryType::ProjectMatch)
+    {
+    }
+
+    Json::Value ProjectMatchEntry::ToJson() const
+    {
+        auto json = NewProjectMenuEntry::ToJson();
+
+        JsonUtils::SetValueForKey(json, NameKey, _Name);
+        JsonUtils::SetValueForKey(json, CommandlineKey, _Commandline);
+        JsonUtils::SetValueForKey(json, SourceKey, _Source);
+
+        return json;
+    }
+
+    winrt::com_ptr<NewProjectMenuEntry> ProjectMatchEntry::FromJson(const Json::Value& json)
+    {
+        auto entry = winrt::make_self<ProjectMatchEntry>();
+
+        JsonUtils::GetValueForKey(json, NameKey, entry->_Name);
+        entry->_validateAndPopulateNameRegex();
+
+        JsonUtils::GetValueForKey(json, CommandlineKey, entry->_Commandline);
+        entry->_validateAndPopulateCommandlineRegex();
+
+        JsonUtils::GetValueForKey(json, SourceKey, entry->_Source);
+        entry->_validateAndPopulateSourceRegex();
+
+        return entry;
+    }
+
+    // Returns true if all regexes are valid, false otherwise
+    bool ProjectMatchEntry::ValidateRegexes() const
+    {
+        return !(_invalidName || _invalidCommandline || _invalidSource);
+    }
+
+#define DEFINE_VALIDATE_FUNCTION(name)                                    \
+    void ProjectMatchEntry::_validateAndPopulate##name##Regex() noexcept \
+    {                                                                     \
+        _invalid##name = false;                                           \
+        if (_##name.empty())                                              \
+        {                                                                 \
+            /* empty field is valid*/                                     \
+            return;                                                       \
+        }                                                                 \
+        UErrorCode status = U_ZERO_ERROR;                                 \
+        _##name##Regex = til::ICU::CreateRegex(_##name, 0, &status);      \
+        if (U_FAILURE(status))                                            \
+        {                                                                 \
+            _invalid##name = true;                                        \
+            _##name##Regex.reset();                                       \
+        }                                                                 \
+    }
+
+    DEFINE_VALIDATE_FUNCTION(Name);
+    DEFINE_VALIDATE_FUNCTION(Commandline);
+    DEFINE_VALIDATE_FUNCTION(Source);
+
+    bool ProjectMatchEntry::MatchesProfile(const Model::Profile& profile)
+    {
+        auto isMatch = [](const til::ICU::unique_uregex& regex, std::wstring_view text) {
+            if (text.empty())
+            {
+                return false;
+            }
+            UErrorCode status = U_ZERO_ERROR;
+            uregex_setText(regex.get(), reinterpret_cast<const UChar*>(text.data()), static_cast<int32_t>(text.size()), &status);
+            const auto match = uregex_matches(regex.get(), 0, &status);
+            return status == U_ZERO_ERROR && match;
+        };
+
+        if (!_Name.empty() && isMatch(_NameRegex, profile.Name()))
+        {
+            return true;
+        }
+        else if (!_Source.empty() && isMatch(_SourceRegex, profile.Source()))
+        {
+            return true;
+        }
+        else if (!_Commandline.empty() && isMatch(_CommandlineRegex, profile.Commandline()))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    Model::NewProjectMenuEntry ProjectMatchEntry::Copy() const
+    {
+        auto entry = winrt::make_self<ProjectMatchEntry>();
+        entry->_Name = _Name;
+        entry->_Commandline = _Commandline;
+        entry->_Source = _Source;
+        return *entry;
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectMatchEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectMatchEntry.h
@@ -1,0 +1,69 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- ProjectMatchEntry.h
+
+Abstract:
+- An entry in the "new tab" dropdown menu that represents a collection
+    of profiles that match a specified name, source, or command line.
+
+Author(s):
+- Floris Westerman - November 2022
+
+--*/
+#pragma once
+
+#include "ProjectCollectionEntry.h"
+#include "ProjectMatchEntry.g.h"
+#include <til/regex.h>
+
+// This macro defines the getter and setter for a regex property.
+// The setter tries to instantiate the regex immediately and caches
+// it if successful. If it fails, it sets a boolean flag to track that
+// it failed.
+#define DEFINE_MATCH_PROJECT_REGEX_PROPERTY(name)      \
+public:                                                \
+    hstring name() const noexcept                      \
+    {                                                  \
+        return _##name;                                \
+    }                                                  \
+    void name(const hstring& value) noexcept           \
+    {                                                  \
+        _##name = value;                               \
+        _validateAndPopulate##name##Regex();           \
+    }                                                  \
+                                                       \
+private:                                               \
+    void _validateAndPopulate##name##Regex() noexcept; \
+                                                       \
+    hstring _##name;                                   \
+    til::ICU::unique_uregex _##name##Regex;            \
+    bool _invalid##name{ false };
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectMatchEntry : ProjectMatchEntryT<ProjectMatchEntry, ProjectCollectionEntry>
+    {
+    public:
+        ProjectMatchEntry() noexcept;
+
+        Model::NewProjectMenuEntry Copy() const override;
+
+        Json::Value ToJson() const override;
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+
+        bool ValidateRegexes() const;
+        bool MatchesProfile(const Model::Profile& profile);
+
+        DEFINE_MATCH_PROJECT_REGEX_PROPERTY(Name)
+        DEFINE_MATCH_PROJECT_REGEX_PROPERTY(Commandline)
+        DEFINE_MATCH_PROJECT_REGEX_PROPERTY(Source)
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProjectMatchEntry);
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectRemainingEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectRemainingEntry.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectRemainingEntry.h"
+#include "NewProjectMenuEntry.h"
+#include "JsonUtils.h"
+
+#include "ProjectRemainingEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    ProjectRemainingEntry::ProjectRemainingEntry() noexcept :
+        ProjectRemainingEntryT<ProjectRemainingEntry, ProjectCollectionEntry>(NewProjectMenuEntryType::ProjectRemaining)
+    {
+    }
+
+    winrt::com_ptr<NewProjectMenuEntry> ProjectRemainingEntry::FromJson(const Json::Value&)
+    {
+        return winrt::make_self<ProjectRemainingEntry>();
+    }
+
+    Model::NewProjectMenuEntry ProjectRemainingEntry::Copy() const
+    {
+        return winrt::make<ProjectRemainingEntry>();
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectRemainingEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectRemainingEntry.h
@@ -1,0 +1,37 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- SeparatorEntry.h
+
+Abstract:
+- An entry in the "new tab" dropdown menu that represents all profiles
+    that were not included explicitly elsewhere
+
+Author(s):
+- Floris Westerman - August 2022
+
+--*/
+#pragma once
+
+#include "ProjectCollectionEntry.h"
+#include "ProjectRemainingEntry.g.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectRemainingEntry : ProjectRemainingEntryT<ProjectRemainingEntry, ProjectCollectionEntry>
+    {
+    public:
+        ProjectRemainingEntry() noexcept;
+
+        Model::NewProjectMenuEntry Copy() const override;
+
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProjectRemainingEntry);
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectSeparatorEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProjectSeparatorEntry.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProjectSeparatorEntry.h"
+#include "JsonUtils.h"
+
+#include "ProjectSeparatorEntry.g.cpp"
+
+using namespace Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    ProjectSeparatorEntry::ProjectSeparatorEntry() noexcept :
+        ProjectSeparatorEntryT<ProjectSeparatorEntry, NewProjectMenuEntry>(NewProjectMenuEntryType::ProjectSeparator)
+    {
+    }
+
+    winrt::com_ptr<NewProjectMenuEntry> ProjectSeparatorEntry::FromJson(const Json::Value&)
+    {
+        return winrt::make_self<ProjectSeparatorEntry>();
+    }
+
+    Model::NewProjectMenuEntry ProjectSeparatorEntry::Copy() const
+    {
+        return winrt::make<ProjectSeparatorEntry>();
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProjectSeparatorEntry.h
+++ b/src/cascadia/TerminalSettingsModel/ProjectSeparatorEntry.h
@@ -1,0 +1,36 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- SeparatorEntry.h
+
+Abstract:
+- A separator entry in the "new tab" dropdown menu
+
+Author(s):
+- Floris Westerman - August 2022
+
+--*/
+#pragma once
+
+#include "NewProjectMenuEntry.h"
+#include "ProjectSeparatorEntry.g.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    struct ProjectSeparatorEntry : ProjectSeparatorEntryT<ProjectSeparatorEntry, NewProjectMenuEntry>
+    {
+    public:
+        ProjectSeparatorEntry() noexcept;
+
+        Model::NewProjectMenuEntry Copy() const override;
+
+        static com_ptr<NewProjectMenuEntry> FromJson(const Json::Value& json);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProjectSeparatorEntry);
+}

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -691,8 +691,30 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::NewTabMenuEntryT
     };
 };
 
+// Possible NewProjectMenuEntryType values
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::NewProjectMenuEntryType)
+{
+    JSON_MAPPINGS(6) = {
+        pair_type{ "project", ValueType::Project },
+        pair_type{ "projectAction", ValueType::ProjectAction },
+        pair_type{ "projectSeparator", ValueType::ProjectSeparator },
+        pair_type{ "projectFolder", ValueType::ProjectFolder },
+        pair_type{ "projectRemaining", ValueType::ProjectRemaining },
+        pair_type{ "projectMatch", ValueType::ProjectMatch },
+    };
+};
+
 // Possible FolderEntryInlining values
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FolderEntryInlining)
+{
+    JSON_MAPPINGS(2) = {
+        pair_type{ "never", ValueType::Never },
+        pair_type{ "auto", ValueType::Auto },
+    };
+};
+
+// Possible ProjectFolderEntryInlining values
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::ProjectFolderEntryInlining)
 {
     JSON_MAPPINGS(2) = {
         pair_type{ "never", ValueType::Never },

--- a/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
@@ -36,6 +36,7 @@
     <ClInclude Include="../KeyChordSerialization.h" />
     <ClInclude Include="../KeyMapping.h" />
     <ClInclude Include="../Profile.h" />
+    <ClInclude Include="../Project.h" />
     <ClInclude Include="../TerminalWarnings.h" />
     <ClInclude Include="../NewTabMenuEntry.h" />
     <ClInclude Include="../ActionEntry.h">
@@ -58,6 +59,28 @@
     </ClInclude>
     <ClInclude Include="../MatchProfilesEntry.h">
       <DependentUpon>../NewTabMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../NewProjectMenuEntry.h" />
+    <ClInclude Include="../ProjectActionEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../ProjectSeparatorEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../ProjectFolderEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../ProjectEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../ProjectRemainingEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../ProjectCollectionEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="../ProjectMatchEntry.h">
+      <DependentUpon>../NewProjectMenuEntry.h</DependentUpon>
     </ClInclude>
   </ItemGroup>
   <!-- ========================= Cpp Files ======================== -->
@@ -89,7 +112,6 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:true and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -98,7 +120,6 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
     <!-- Reference Microsoft.Terminal.Settings.ModelLib here, so we can use its winmd as
     our winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
@@ -106,7 +127,6 @@
       <Private>true</Private>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
     MDMERGE will know where the TermControl types are defined. However, we need
@@ -118,7 +138,6 @@
       <Private>false</Private>
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
-
     <Reference Include="Microsoft.Terminal.Core">
       <HintPath>$(OpenConsoleCommonOutDir)TerminalCore\Microsoft.Terminal.Core.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
@@ -126,7 +145,6 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
   </ItemGroup>
-
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);user32.lib;$(IntDir)\..\Microsoft.Terminal.Settings.Model.lib\Microsoft.Terminal.Settings.Model.res</AdditionalDependencies>
@@ -140,7 +158,6 @@
     </Reference>
   </ItemDefinitionGroup>
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
-
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
 </Project>

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -376,7 +376,7 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
 
 		// Create another window if needed: There aren't any yet, or we got an explicit command line.
 		if (_windows.empty() ||
-			(args.size() > 1 && (cmdArgs.LocalState().empty() || cmdArgs.ProjectName().empty())) ||
+			(args.size() > 1 && (cmdArgs.LocalState().empty() && cmdArgs.ProjectName().empty())) ||
 			args.size() > 3) // LocalState is 2 additional strings
 		{
 			_dispatchCommandline({ args, cwd, showCmd, env });

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -25,6 +25,7 @@ using namespace std::chrono_literals;
 using VirtualKeyModifiers = winrt::Windows::System::VirtualKeyModifiers;
 
 #define ENV_WT_BASE_SETTINGS_PATH L"WT_BASE_SETTINGS_PATH"
+#define ENV_WT_PROJECT_NAME L"WT_PROJECT_NAME"
 
 #ifdef _WIN64
 static constexpr ULONG_PTR TERMINAL_HANDOFF_MAGIC = 0x4c414e494d524554; // 'TERMINAL'
@@ -37,1134 +38,1140 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 // A convenience function around CommandLineToArgv.
 static std::vector<winrt::hstring> commandlineToArgArray(const wchar_t* commandLine)
 {
-    int argc = 0;
-    const wil::unique_hlocal_ptr<LPWSTR> argv{ CommandLineToArgvW(commandLine, &argc) };
-    argc = std::max(argc, 0);
+	int argc = 0;
+	const wil::unique_hlocal_ptr<LPWSTR> argv{ CommandLineToArgvW(commandLine, &argc) };
+	argc = std::max(argc, 0);
 
-    std::vector<winrt::hstring> args;
-    args.reserve(argc);
-    for (int i = 0; i < argc; i++)
-    {
-        args.emplace_back(argv.get()[i]);
-    }
-    return args;
+	std::vector<winrt::hstring> args;
+	args.reserve(argc);
+	for (int i = 0; i < argc; i++)
+	{
+		args.emplace_back(argv.get()[i]);
+	}
+	return args;
 }
 
 // Returns the length of a double-null encoded string *excluding* the trailing double-null character.
 static std::wstring_view stringFromDoubleNullTerminated(const wchar_t* beg)
 {
-    auto end = beg;
+	auto end = beg;
 
-    for (; *end; end += wcsnlen(end, SIZE_T_MAX) + 1)
-    {
-    }
+	for (; *end; end += wcsnlen(end, SIZE_T_MAX) + 1)
+	{
+	}
 
-    return { beg, end };
+	return { beg, end };
 }
 
 // Appends an uint32_t to a byte vector.
 static void serializeUint32(std::vector<uint8_t>& out, uint32_t value)
 {
-    out.insert(out.end(), reinterpret_cast<const uint8_t*>(&value), reinterpret_cast<const uint8_t*>(&value) + sizeof(value));
+	out.insert(out.end(), reinterpret_cast<const uint8_t*>(&value), reinterpret_cast<const uint8_t*>(&value) + sizeof(value));
 }
 
 // Parses an uint32_t from the input iterator. Performs bounds-checks.
 // Returns an iterator that points past it.
 static const uint8_t* deserializeUint32(const uint8_t* it, const uint8_t* end, uint32_t& val)
 {
-    if (static_cast<size_t>(end - it) < sizeof(uint32_t))
-    {
-        throw std::out_of_range("Not enough data for uint32_t");
-    }
-    val = *reinterpret_cast<const uint32_t*>(it);
-    return it + sizeof(uint32_t);
+	if (static_cast<size_t>(end - it) < sizeof(uint32_t))
+	{
+		throw std::out_of_range("Not enough data for uint32_t");
+	}
+	val = *reinterpret_cast<const uint32_t*>(it);
+	return it + sizeof(uint32_t);
 }
 
 // Writes an uint32_t length prefix, followed by the string data, to the output vector.
 static void serializeString(std::vector<uint8_t>& out, std::wstring_view str)
 {
-    const auto ptr = reinterpret_cast<const uint8_t*>(str.data());
-    const auto len = gsl::narrow<uint32_t>(str.size());
-    serializeUint32(out, len);
-    out.insert(out.end(), ptr, ptr + len * sizeof(wchar_t));
+	const auto ptr = reinterpret_cast<const uint8_t*>(str.data());
+	const auto len = gsl::narrow<uint32_t>(str.size());
+	serializeUint32(out, len);
+	out.insert(out.end(), ptr, ptr + len * sizeof(wchar_t));
 }
 
 // Parses the next string from the input iterator. Performs bounds-checks.
 // Returns an iterator that points past it.
 static const uint8_t* deserializeString(const uint8_t* it, const uint8_t* end, std::wstring_view& str)
 {
-    uint32_t len;
-    it = deserializeUint32(it, end, len);
+	uint32_t len;
+	it = deserializeUint32(it, end, len);
 
-    if (static_cast<size_t>(end - it) < len * sizeof(wchar_t))
-    {
-        throw std::out_of_range("Not enough data for string content");
-    }
+	if (static_cast<size_t>(end - it) < len * sizeof(wchar_t))
+	{
+		throw std::out_of_range("Not enough data for string content");
+	}
 
-    str = { reinterpret_cast<const wchar_t*>(it), len };
-    return it + len * sizeof(wchar_t);
+	str = { reinterpret_cast<const wchar_t*>(it), len };
+	return it + len * sizeof(wchar_t);
 }
 
 struct Handoff
 {
-    std::wstring_view args;
-    std::wstring_view env;
-    std::wstring_view cwd;
-    uint32_t show;
+	std::wstring_view args;
+	std::wstring_view env;
+	std::wstring_view cwd;
+	uint32_t show;
 };
 
 // Serializes all relevant parameters to a byte blob for a WM_COPYDATA message.
 // This allows us to hand off an invocation to an existing instance of the Terminal.
 static std::vector<uint8_t> serializeHandoffPayload(int nCmdShow)
 {
-    const auto args = GetCommandLineW();
-    const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
-    const auto env = stringFromDoubleNullTerminated(envMem.get());
-    const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
+	const auto args = GetCommandLineW();
+	const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
+	const auto env = stringFromDoubleNullTerminated(envMem.get());
+	const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
 
-    std::vector<uint8_t> out;
-    serializeString(out, args);
-    serializeString(out, env);
-    serializeString(out, cwd);
-    serializeUint32(out, static_cast<uint32_t>(nCmdShow));
-    return out;
+	std::vector<uint8_t> out;
+	serializeString(out, args);
+	serializeString(out, env);
+	serializeString(out, cwd);
+	serializeUint32(out, static_cast<uint32_t>(nCmdShow));
+	return out;
 }
 
 // Counterpart to serializeHandoffPayload.
 static Handoff deserializeHandoffPayload(const uint8_t* beg, const uint8_t* end)
 {
-    Handoff result{};
-    auto it = beg;
-    it = deserializeString(it, end, result.args);
-    it = deserializeString(it, end, result.env);
-    it = deserializeString(it, end, result.cwd);
-    it = deserializeUint32(it, end, result.show);
-    return result;
+	Handoff result{};
+	auto it = beg;
+	it = deserializeString(it, end, result.args);
+	it = deserializeString(it, end, result.env);
+	it = deserializeString(it, end, result.cwd);
+	it = deserializeUint32(it, end, result.show);
+	return result;
 }
 
 // Either acquires unique ownership over the given `className` mutex,
 // or attempts to pass the commandline to the existing instance.
 static wil::unique_mutex acquireMutexOrAttemptHandoff(const wchar_t* className, int nCmdShow)
 {
-    // If the process that owns the mutex has not finished creating the window yet,
-    // FindWindowW will return nullptr. We'll retry a few times just in case.
-    // At the 1.5x growth rate, this will retry up to ~30s in total.
-    for (DWORD sleep = 50; sleep < 10000; sleep += sleep / 2)
-    {
-        wil::unique_mutex mutex{ CreateMutexW(nullptr, TRUE, className) };
-        if (GetLastError() == ERROR_ALREADY_EXISTS)
-        {
-            mutex.reset();
-        }
-        if (mutex)
-        {
-            return mutex;
-        }
+	// If the process that owns the mutex has not finished creating the window yet,
+	// FindWindowW will return nullptr. We'll retry a few times just in case.
+	// At the 1.5x growth rate, this will retry up to ~30s in total.
+	for (DWORD sleep = 50; sleep < 10000; sleep += sleep / 2)
+	{
+		wil::unique_mutex mutex{ CreateMutexW(nullptr, TRUE, className) };
+		if (GetLastError() == ERROR_ALREADY_EXISTS)
+		{
+			mutex.reset();
+		}
+		if (mutex)
+		{
+			return mutex;
+		}
 
-        // I found that FindWindow() with no other filters is substantially faster than
-        // using FindWindowEx() and restricting the search to just HWND_MESSAGE windows.
-        // In both cases it's quite fast though at ~1us/op vs ~3us/op (good old Win32 <3).
-        if (const auto hwnd = FindWindowW(className, nullptr))
-        {
-            auto payload = serializeHandoffPayload(nCmdShow);
-            const COPYDATASTRUCT cds{
-                .dwData = TERMINAL_HANDOFF_MAGIC,
-                .cbData = gsl::narrow<DWORD>(payload.size()),
-                .lpData = payload.data(),
-            };
+		// I found that FindWindow() with no other filters is substantially faster than
+		// using FindWindowEx() and restricting the search to just HWND_MESSAGE windows.
+		// In both cases it's quite fast though at ~1us/op vs ~3us/op (good old Win32 <3).
+		if (const auto hwnd = FindWindowW(className, nullptr))
+		{
+			auto payload = serializeHandoffPayload(nCmdShow);
+			const COPYDATASTRUCT cds{
+				.dwData = TERMINAL_HANDOFF_MAGIC,
+				.cbData = gsl::narrow<DWORD>(payload.size()),
+				.lpData = payload.data(),
+			};
 
-            // Allow the existing instance to gain foreground rights.
-            DWORD processId = 0;
-            if (GetWindowThreadProcessId(hwnd, &processId) && processId)
-            {
-                AllowSetForegroundWindow(processId);
-            }
+			// Allow the existing instance to gain foreground rights.
+			DWORD processId = 0;
+			if (GetWindowThreadProcessId(hwnd, &processId) && processId)
+			{
+				AllowSetForegroundWindow(processId);
+			}
 
-            if (SendMessageTimeoutW(hwnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&cds), SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, 5000, nullptr))
-            {
-                return {};
-            }
-        }
+			if (SendMessageTimeoutW(hwnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&cds), SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, 5000, nullptr))
+			{
+				return {};
+			}
+		}
 
-        Sleep(sleep);
-    }
+		Sleep(sleep);
+	}
 
-    return {};
+	return {};
 }
 
 HWND WindowEmperor::GetMainWindow() const noexcept
 {
-    _assertIsMainThread();
-    return _window.get();
+	_assertIsMainThread();
+	return _window.get();
 }
 
 AppHost* WindowEmperor::GetWindowById(uint64_t id) const noexcept
 {
-    _assertIsMainThread();
+	_assertIsMainThread();
 
-    for (const auto& window : _windows)
-    {
-        if (window->Logic().WindowProperties().WindowId() == id)
-        {
-            return window.get();
-        }
-    }
-    return nullptr;
+	for (const auto& window : _windows)
+	{
+		if (window->Logic().WindowProperties().WindowId() == id)
+		{
+			return window.get();
+		}
+	}
+	return nullptr;
 }
 
 AppHost* WindowEmperor::GetWindowByName(std::wstring_view name) const noexcept
 {
-    _assertIsMainThread();
+	_assertIsMainThread();
 
-    for (const auto& window : _windows)
-    {
-        if (window->Logic().WindowProperties().WindowName() == name)
-        {
-            return window.get();
-        }
-    }
-    return nullptr;
+	for (const auto& window : _windows)
+	{
+		if (window->Logic().WindowProperties().WindowName() == name)
+		{
+			return window.get();
+		}
+	}
+	return nullptr;
 }
 
 void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args)
 {
-    _assertIsMainThread();
+	_assertIsMainThread();
 
-    uint64_t id = args.Id();
-    bool needsNewId = id == 0;
-    uint64_t newId = 0;
+	uint64_t id = args.Id();
+	bool needsNewId = id == 0;
+	uint64_t newId = 0;
 
-    for (const auto& host : _windows)
-    {
-        const auto existingId = host->Logic().WindowProperties().WindowId();
-        newId = std::max(newId, existingId);
-        needsNewId |= existingId == id;
-    }
+	for (const auto& host : _windows)
+	{
+		const auto existingId = host->Logic().WindowProperties().WindowId();
+		newId = std::max(newId, existingId);
+		needsNewId |= existingId == id;
+	}
 
-    if (needsNewId)
-    {
-        args.Id(newId + 1);
-    }
+	if (needsNewId)
+	{
+		args.Id(newId + 1);
+	}
 
-    auto host = std::make_shared<AppHost>(this, _app.Logic(), std::move(args));
-    host->Initialize();
+	auto host = std::make_shared<AppHost>(this, _app.Logic(), std::move(args));
+	host->Initialize();
 
-    _windowCount += 1;
-    _windows.emplace_back(std::move(host));
+	_windowCount += 1;
+	_windows.emplace_back(std::move(host));
 }
 
 AppHost* WindowEmperor::_mostRecentWindow() const noexcept
 {
-    int64_t max = INT64_MIN;
-    AppHost* mostRecent = nullptr;
+	int64_t max = INT64_MIN;
+	AppHost* mostRecent = nullptr;
 
-    for (const auto& w : _windows)
-    {
-        const auto lastActivatedTime = w->GetLastActivatedTime();
-        if (lastActivatedTime > max)
-        {
-            max = lastActivatedTime;
-            mostRecent = w.get();
-        }
-    }
+	for (const auto& w : _windows)
+	{
+		const auto lastActivatedTime = w->GetLastActivatedTime();
+		if (lastActivatedTime > max)
+		{
+			max = lastActivatedTime;
+			mostRecent = w.get();
+		}
+	}
 
-    return mostRecent;
+	return mostRecent;
 }
 
 void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
 {
-    std::wstring windowClassName;
-    windowClassName.reserve(47); // "Windows Terminal Preview Admin 0123456789012345"
+	std::wstring windowClassName;
+	windowClassName.reserve(47); // "Windows Terminal Preview Admin 0123456789012345"
 #if defined(WT_BRANDING_RELEASE)
-    windowClassName.append(L"Windows Terminal");
+	windowClassName.append(L"Windows Terminal");
 #elif defined(WT_BRANDING_PREVIEW)
-    windowClassName.append(L"Windows Terminal Preview");
+	windowClassName.append(L"Windows Terminal Preview");
 #elif defined(WT_BRANDING_CANARY)
-    windowClassName.append(L"Windows Terminal Canary");
+	windowClassName.append(L"Windows Terminal Canary");
 #else
-    windowClassName.append(L"Windows Terminal Dev");
+	windowClassName.append(L"Windows Terminal Dev");
 #endif
-    if (Utils::IsRunningElevated())
-    {
-        windowClassName.append(L" Admin");
-    }
-    if (!IsPackaged())
-    {
-        const auto path = wil::GetModuleFileNameW<std::wstring>(nullptr);
-        const auto hash = til::hash(path);
+	if (Utils::IsRunningElevated())
+	{
+		windowClassName.append(L" Admin");
+	}
+	if (!IsPackaged())
+	{
+		const auto path = wil::GetModuleFileNameW<std::wstring>(nullptr);
+		const auto hash = til::hash(path);
 #ifdef _WIN64
-        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), hash);
+		fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), hash);
 #else
-        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), hash);
+		fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), hash);
 #endif
-    }
+	}
 
-    const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
-    const auto env = stringFromDoubleNullTerminated(envMem.get());
-    const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
-    const auto showCmd = gsl::narrow_cast<uint32_t>(nCmdShow);
-    const auto args = commandlineToArgArray(GetCommandLineW());
-    winrt::TerminalApp::CommandlineArgs cmdArgs{ args, cwd, showCmd, env };
+	const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
+	const auto env = stringFromDoubleNullTerminated(envMem.get());
+	const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
+	const auto showCmd = gsl::narrow_cast<uint32_t>(nCmdShow);
+	const auto args = commandlineToArgArray(GetCommandLineW());
+	winrt::TerminalApp::CommandlineArgs cmdArgs{ args, cwd, showCmd, env };
 
-    try
-    {
-        const auto settingsPath = cmdArgs.LocalState().c_str();
-        SetEnvironmentVariableW(ENV_WT_BASE_SETTINGS_PATH, settingsPath);
-        const auto settingsHash = til::hash(settingsPath);
+	try
+	{
+		const auto settingsPath = cmdArgs.LocalState().c_str();
+		SetEnvironmentVariableW(ENV_WT_BASE_SETTINGS_PATH, settingsPath);
+		const auto settingsHash = til::hash(settingsPath);
+
+		const auto projectName = cmdArgs.ProjectName().c_str();
+		SetEnvironmentVariableW(ENV_WT_PROJECT_NAME, projectName);
+		const auto projectHash = til::hash(projectName);
 #ifdef _WIN64
-        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), settingsHash);
+		fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), settingsHash);
+		fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), projectHash);
 #else
-        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), settingsHash);
+		fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), settingsHash);
+		fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), projectHash);
 #endif
-    }
-    CATCH_LOG()
+	}
+	CATCH_LOG()
 
-    // Windows Terminal is a single-instance application. Either acquire ownership
-    // over the mutex, or hand off the command line to the existing instance.
-    const auto mutex = acquireMutexOrAttemptHandoff(windowClassName.c_str(), nCmdShow);
-    if (!mutex)
-    {
-        // The command line has been handed off. We can now exit.
-        // We do it with TerminateProcess() primarily to avoid WinUI shutdown issues.
-        TerminateProcess(GetCurrentProcess(), gsl::narrow_cast<UINT>(0));
-        __assume(false);
-    }
+	// Windows Terminal is a single-instance application. Either acquire ownership
+	// over the mutex, or hand off the command line to the existing instance.
+	const auto mutex = acquireMutexOrAttemptHandoff(windowClassName.c_str(), nCmdShow);
+	if (!mutex)
+	{
+		// The command line has been handed off. We can now exit.
+		// We do it with TerminateProcess() primarily to avoid WinUI shutdown issues.
+		TerminateProcess(GetCurrentProcess(), gsl::narrow_cast<UINT>(0));
+		__assume(false);
+	}
 
-    _app = winrt::TerminalApp::App{};
-    _app.Logic().ReloadSettings();
+	_app = winrt::TerminalApp::App{};
+	_app.Logic().ReloadSettings();
 
-    _createMessageWindow(windowClassName.c_str());
-    _setupGlobalHotkeys();
-    _checkWindowsForNotificationIcon();
-    _setupSessionPersistence(_app.Logic().Settings().GlobalSettings().ShouldUsePersistedLayout());
+	_createMessageWindow(windowClassName.c_str());
+	_setupGlobalHotkeys();
+	_checkWindowsForNotificationIcon();
+	_setupSessionPersistence(_app.Logic().Settings().GlobalSettings().ShouldUsePersistedLayout());
 
-    // When the settings change, we'll want to update our global hotkeys
-    // and our notification icon based on the new settings.
-    _app.Logic().SettingsChanged([this](auto&&, const TerminalApp::SettingsLoadEventArgs& args) {
-        if (SUCCEEDED(args.Result()))
-        {
-            _assertIsMainThread();
-            _setupGlobalHotkeys();
-            _checkWindowsForNotificationIcon();
-            _setupSessionPersistence(args.NewSettings().GlobalSettings().ShouldUsePersistedLayout());
-        }
-    });
+	// When the settings change, we'll want to update our global hotkeys
+	// and our notification icon based on the new settings.
+	_app.Logic().SettingsChanged([this](auto&&, const TerminalApp::SettingsLoadEventArgs& args) {
+		if (SUCCEEDED(args.Result()))
+		{
+			_assertIsMainThread();
+			_setupGlobalHotkeys();
+			_checkWindowsForNotificationIcon();
+			_setupSessionPersistence(args.NewSettings().GlobalSettings().ShouldUsePersistedLayout());
+		}
+	});
 
-    {
-        // Restore persisted windows.
-        const auto state = ApplicationState::SharedInstance();
-        const auto layouts = state.PersistedWindowLayouts();
-        if (layouts && layouts.Size() > 0)
-        {
-            _needsPersistenceCleanup = true;
+	{
+		// Restore persisted windows.
+		const auto state = ApplicationState::SharedInstance();
+		const auto layouts = state.PersistedWindowLayouts();
+		if (layouts && layouts.Size() > 0)
+		{
+			_needsPersistenceCleanup = true;
 
-            uint32_t startIdx = 0;
-            for (const auto layout : layouts)
-            {
-                hstring _args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
-                _dispatchCommandline({ _args, cwd, showCmd, env });
-                startIdx += 1;
-            }
-        }
+			uint32_t startIdx = 0;
+			for (const auto layout : layouts)
+			{
+				hstring _args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
+				_dispatchCommandline({ _args, cwd, showCmd, env });
+				startIdx += 1;
+			}
+		}
 
-        // Create another window if needed: There aren't any yet, or we got an explicit command line.
-        if (_windows.empty() ||
-           (args.size() > 1 && cmdArgs.LocalState().empty()) ||
-            args.size() > 3) // LocalState is 2 additional strings
-        {
-            _dispatchCommandline({ args, cwd, showCmd, env });
-        }
+		// Create another window if needed: There aren't any yet, or we got an explicit command line.
+		if (_windows.empty() ||
+			(args.size() > 1 && (cmdArgs.LocalState().empty() || cmdArgs.ProjectName().empty())) ||
+			args.size() > 3) // LocalState is 2 additional strings
+		{
+			_dispatchCommandline({ args, cwd, showCmd, env });
+		}
 
-        // If we created no windows, e.g. because the args are "/?" we can just exit now.
-        _postQuitMessageIfNeeded();
-    }
+		// If we created no windows, e.g. because the args are "/?" we can just exit now.
+		_postQuitMessageIfNeeded();
+	}
 
-    // ALWAYS change the _real_ CWD of the Terminal to system32,
-    // so that we don't lock the directory we were spawned in.
-    if (std::wstring system32; SUCCEEDED_LOG(wil::GetSystemDirectoryW(system32)))
-    {
-        LOG_IF_WIN32_BOOL_FALSE(SetCurrentDirectoryW(system32.c_str()));
-    }
+	// ALWAYS change the _real_ CWD of the Terminal to system32,
+	// so that we don't lock the directory we were spawned in.
+	if (std::wstring system32; SUCCEEDED_LOG(wil::GetSystemDirectoryW(system32)))
+	{
+		LOG_IF_WIN32_BOOL_FALSE(SetCurrentDirectoryW(system32.c_str()));
+	}
 
-    // The first CoreWindow is created implicitly by XAML and parented to the
-    // first XAML island. We parent it to our initial window for 2 reasons:
-    // * On Windows 10 the CoreWindow will show up as a visible window on the taskbar
-    //   due to a WinUI bug, and this will hide it, because our initial window is hidden.
-    // * When we DestroyWindow() the island it will destroy the CoreWindow,
-    //   and it's not possible to recreate it. That's also a WinUI bug.
-    if (const auto coreWindow = winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread())
-    {
-        if (const auto interop = coreWindow.try_as<ICoreWindowInterop>())
-        {
-            HWND coreHandle = nullptr;
-            if (SUCCEEDED(interop->get_WindowHandle(&coreHandle)) && coreHandle)
-            {
-                SetParent(coreHandle, _window.get());
-            }
-        }
-    }
+	// The first CoreWindow is created implicitly by XAML and parented to the
+	// first XAML island. We parent it to our initial window for 2 reasons:
+	// * On Windows 10 the CoreWindow will show up as a visible window on the taskbar
+	//   due to a WinUI bug, and this will hide it, because our initial window is hidden.
+	// * When we DestroyWindow() the island it will destroy the CoreWindow,
+	//   and it's not possible to recreate it. That's also a WinUI bug.
+	if (const auto coreWindow = winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread())
+	{
+		if (const auto interop = coreWindow.try_as<ICoreWindowInterop>())
+		{
+			HWND coreHandle = nullptr;
+			if (SUCCEEDED(interop->get_WindowHandle(&coreHandle)) && coreHandle)
+			{
+				SetParent(coreHandle, _window.get());
+			}
+		}
+	}
 
-    // Main message loop. It pumps all windows.
-    bool loggedInteraction = false;
-    MSG msg{};
-    while (GetMessageW(&msg, nullptr, 0, 0))
-    {
-        // This is `if (WM_KEYDOWN || WM_KEYUP || WM_SYSKEYDOWN || WM_SYSKEYUP)`.
-        // It really doesn't need to be written that obtuse, but it at
-        // least nicely mirrors our `keyDown = msg.message & 1` logic.
-        // FYI: For the key-down/up messages the lowest bit indicates if it's up.
-        if ((msg.message & ~1) == WM_KEYDOWN || (msg.message & ~1) == WM_SYSKEYDOWN)
-        {
-            if (!loggedInteraction)
-            {
+	// Main message loop. It pumps all windows.
+	bool loggedInteraction = false;
+	MSG msg{};
+	while (GetMessageW(&msg, nullptr, 0, 0))
+	{
+		// This is `if (WM_KEYDOWN || WM_KEYUP || WM_SYSKEYDOWN || WM_SYSKEYUP)`.
+		// It really doesn't need to be written that obtuse, but it at
+		// least nicely mirrors our `keyDown = msg.message & 1` logic.
+		// FYI: For the key-down/up messages the lowest bit indicates if it's up.
+		if ((msg.message & ~1) == WM_KEYDOWN || (msg.message & ~1) == WM_SYSKEYDOWN)
+		{
+			if (!loggedInteraction)
+			{
 #if defined(WT_BRANDING_RELEASE)
-                constexpr uint8_t branding = 3;
+				constexpr uint8_t branding = 3;
 #elif defined(WT_BRANDING_PREVIEW)
-                constexpr uint8_t branding = 2;
+				constexpr uint8_t branding = 2;
 #elif defined(WT_BRANDING_CANARY)
-                constexpr uint8_t branding = 1;
+				constexpr uint8_t branding = 1;
 #else
-                constexpr uint8_t branding = 0;
+				constexpr uint8_t branding = 0;
 #endif
-                const uint8_t distribution = IsPackaged()                             ? 2 :
-                                             _app.Logic().Settings().IsPortableMode() ? 1 :
-                                                                                        0;
-                TraceLoggingWrite(
-                    g_hWindowsTerminalProvider,
-                    "SessionBecameInteractive",
-                    TraceLoggingDescription("Event emitted when the session was interacted with"),
-                    TraceLoggingValue(branding, "Branding"),
-                    TraceLoggingValue(distribution, "Distribution"),
-                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-                    TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
-                loggedInteraction = true;
-            }
+				const uint8_t distribution = IsPackaged()                             ? 2 :
+											 _app.Logic().Settings().IsPortableMode() ? 1 :
+																						0;
+				TraceLoggingWrite(
+					g_hWindowsTerminalProvider,
+					"SessionBecameInteractive",
+					TraceLoggingDescription("Event emitted when the session was interacted with"),
+					TraceLoggingValue(branding, "Branding"),
+					TraceLoggingValue(distribution, "Distribution"),
+					TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+					TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+				loggedInteraction = true;
+			}
 
-            const bool keyDown = (msg.message & 1) == 0;
-            if (
-                // GH#638: The Xaml input stack doesn't allow an application to suppress the "caret browsing"
-                // dialog experience triggered when you press F7. Official recommendation from the Xaml
-                // team is to catch F7 before we hand it off.
-                (msg.wParam == VK_F7 && keyDown) ||
-                // GH#6421: System XAML will never send an Alt KeyUp event. Same thing here.
-                (msg.wParam == VK_MENU && !keyDown) ||
-                // GH#7125: System XAML will show a system dialog on Alt Space.
-                // We want to handle it ourselves and there's no way to suppress it.
-                // It almost seems like there's a pattern here...
-                (msg.wParam == VK_SPACE && msg.message == WM_SYSKEYDOWN))
-            {
-                _dispatchSpecialKey(msg);
-                continue;
-            }
+			const bool keyDown = (msg.message & 1) == 0;
+			if (
+				// GH#638: The Xaml input stack doesn't allow an application to suppress the "caret browsing"
+				// dialog experience triggered when you press F7. Official recommendation from the Xaml
+				// team is to catch F7 before we hand it off.
+				(msg.wParam == VK_F7 && keyDown) ||
+				// GH#6421: System XAML will never send an Alt KeyUp event. Same thing here.
+				(msg.wParam == VK_MENU && !keyDown) ||
+				// GH#7125: System XAML will show a system dialog on Alt Space.
+				// We want to handle it ourselves and there's no way to suppress it.
+				// It almost seems like there's a pattern here...
+				(msg.wParam == VK_SPACE && msg.message == WM_SYSKEYDOWN))
+			{
+				_dispatchSpecialKey(msg);
+				continue;
+			}
 
-            if (msg.message == WM_KEYDOWN)
-            {
-                IslandWindow::HideCursor();
-            }
-        }
+			if (msg.message == WM_KEYDOWN)
+			{
+				IslandWindow::HideCursor();
+			}
+		}
 
-        if (IslandWindow::IsCursorHidden())
-        {
-            IslandWindow::ShowCursorMaybe(msg.message);
-        }
+		if (IslandWindow::IsCursorHidden())
+		{
+			IslandWindow::ShowCursorMaybe(msg.message);
+		}
 
-        TranslateMessage(&msg);
-        DispatchMessageW(&msg);
-    }
+		TranslateMessage(&msg);
+		DispatchMessageW(&msg);
+	}
 
-    _finalizeSessionPersistence();
+	_finalizeSessionPersistence();
 
-    if (_notificationIconShown)
-    {
-        Shell_NotifyIconW(NIM_DELETE, &_notificationIcon);
-    }
+	if (_notificationIconShown)
+	{
+		Shell_NotifyIconW(NIM_DELETE, &_notificationIcon);
+	}
 
-    // There's a mysterious crash in XAML on Windows 10 if you just let _app get destroyed (GH#15410).
-    // We also need to ensure that all UI threads exit before WindowEmperor leaves the scope on the main thread (MSFT:46744208).
-    // Both problems can be solved and the shutdown accelerated by using TerminateProcess.
-    // std::exit(), etc., cannot be used here, because those use ExitProcess for unpackaged applications.
-    TerminateProcess(GetCurrentProcess(), gsl::narrow_cast<UINT>(0));
-    __assume(false);
+	// There's a mysterious crash in XAML on Windows 10 if you just let _app get destroyed (GH#15410).
+	// We also need to ensure that all UI threads exit before WindowEmperor leaves the scope on the main thread (MSFT:46744208).
+	// Both problems can be solved and the shutdown accelerated by using TerminateProcess.
+	// std::exit(), etc., cannot be used here, because those use ExitProcess for unpackaged applications.
+	TerminateProcess(GetCurrentProcess(), gsl::narrow_cast<UINT>(0));
+	__assume(false);
 }
 
 void WindowEmperor::_dispatchSpecialKey(const MSG& msg) const
 {
-    // Each CoreInput window is a child of our IslandWindow.
-    // We can figure out the IslandWindow HWND via GetAncestor().
-    const auto hwnd = GetAncestor(msg.hwnd, GA_ROOT);
-    AppHost* window = nullptr;
+	// Each CoreInput window is a child of our IslandWindow.
+	// We can figure out the IslandWindow HWND via GetAncestor().
+	const auto hwnd = GetAncestor(msg.hwnd, GA_ROOT);
+	AppHost* window = nullptr;
 
-    for (const auto& h : _windows)
-    {
-        const auto w = h->GetWindow();
-        if (w && w->GetHandle() == hwnd)
-        {
-            window = h.get();
-            break;
-        }
-    }
+	for (const auto& h : _windows)
+	{
+		const auto w = h->GetWindow();
+		if (w && w->GetHandle() == hwnd)
+		{
+			window = h.get();
+			break;
+		}
+	}
 
-    // Fallback.
-    if (!window)
-    {
-        window = _mostRecentWindow();
-        if (!window)
-        {
-            return;
-        }
-    }
+	// Fallback.
+	if (!window)
+	{
+		window = _mostRecentWindow();
+		if (!window)
+		{
+			return;
+		}
+	}
 
-    const auto vkey = gsl::narrow_cast<uint32_t>(msg.wParam);
-    const auto scanCode = gsl::narrow_cast<uint8_t>(msg.lParam >> 16);
-    const bool keyDown = (msg.message & 1) == 0;
-    window->OnDirectKeyEvent(vkey, scanCode, keyDown);
+	const auto vkey = gsl::narrow_cast<uint32_t>(msg.wParam);
+	const auto scanCode = gsl::narrow_cast<uint8_t>(msg.lParam >> 16);
+	const bool keyDown = (msg.message & 1) == 0;
+	window->OnDirectKeyEvent(vkey, scanCode, keyDown);
 }
 
 void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs args)
 {
-    const auto exitCode = args.ExitCode();
+	const auto exitCode = args.ExitCode();
 
-    if (const auto msg = args.ExitMessage(); !msg.empty())
-    {
-        _showMessageBox(msg, exitCode != 0);
-        return;
-    }
+	if (const auto msg = args.ExitMessage(); !msg.empty())
+	{
+		_showMessageBox(msg, exitCode != 0);
+		return;
+	}
 
-    if (exitCode != 0)
-    {
-        return;
-    }
+	if (exitCode != 0)
+	{
+		return;
+	}
 
-    const auto parsedTarget = args.TargetWindow();
-    WindowingMode windowingBehavior = WindowingMode::UseNew;
-    uint64_t windowId = 0;
-    winrt::hstring windowName;
+	const auto parsedTarget = args.TargetWindow();
+	WindowingMode windowingBehavior = WindowingMode::UseNew;
+	uint64_t windowId = 0;
+	winrt::hstring windowName;
 
-    // Figure out the windowing behavior the caller wants
-    // and get the sanitized window ID (if any) and window name (if any).
-    if (parsedTarget.empty())
-    {
-        windowingBehavior = _app.Logic().Settings().GlobalSettings().WindowingBehavior();
-    }
-    else if (const auto opt = til::parse_signed<int64_t>(parsedTarget, 10))
-    {
-        // Negative window IDs map to WindowingMode::UseNew.
-        if (*opt > 0)
-        {
-            windowId = gsl::narrow_cast<uint64_t>(*opt);
-        }
-        else if (*opt == 0)
-        {
-            windowingBehavior = WindowingMode::UseExisting;
-        }
-    }
-    else if (parsedTarget == L"last")
-    {
-        windowingBehavior = WindowingMode::UseExisting;
-    }
-    // A window name of "new" maps to WindowingMode::UseNew.
-    else if (parsedTarget != L"new")
-    {
-        windowName = parsedTarget;
-    }
+	// Figure out the windowing behavior the caller wants
+	// and get the sanitized window ID (if any) and window name (if any).
+	if (parsedTarget.empty())
+	{
+		windowingBehavior = _app.Logic().Settings().GlobalSettings().WindowingBehavior();
+	}
+	else if (const auto opt = til::parse_signed<int64_t>(parsedTarget, 10))
+	{
+		// Negative window IDs map to WindowingMode::UseNew.
+		if (*opt > 0)
+		{
+			windowId = gsl::narrow_cast<uint64_t>(*opt);
+		}
+		else if (*opt == 0)
+		{
+			windowingBehavior = WindowingMode::UseExisting;
+		}
+	}
+	else if (parsedTarget == L"last")
+	{
+		windowingBehavior = WindowingMode::UseExisting;
+	}
+	// A window name of "new" maps to WindowingMode::UseNew.
+	else if (parsedTarget != L"new")
+	{
+		windowName = parsedTarget;
+	}
 
-    AppHost* window = nullptr;
+	AppHost* window = nullptr;
 
-    // Map from the windowing behavior, ID, and name to a window.
-    if (windowId)
-    {
-        window = GetWindowById(windowId);
-    }
-    else if (!windowName.empty())
-    {
-        window = GetWindowByName(windowName);
-    }
-    else
-    {
-        switch (windowingBehavior)
-        {
-        case WindowingMode::UseAnyExisting:
-            window = _mostRecentWindow();
-            break;
-        case WindowingMode::UseExisting:
-            _dispatchCommandlineCurrentDesktop(std::move(args));
-            return;
-        default:
-            break;
-        }
-    }
+	// Map from the windowing behavior, ID, and name to a window.
+	if (windowId)
+	{
+		window = GetWindowById(windowId);
+	}
+	else if (!windowName.empty())
+	{
+		window = GetWindowByName(windowName);
+	}
+	else
+	{
+		switch (windowingBehavior)
+		{
+		case WindowingMode::UseAnyExisting:
+			window = _mostRecentWindow();
+			break;
+		case WindowingMode::UseExisting:
+			_dispatchCommandlineCurrentDesktop(std::move(args));
+			return;
+		default:
+			break;
+		}
+	}
 
-    if (window)
-    {
-        window->DispatchCommandline(std::move(args));
-    }
-    else
-    {
-        winrt::TerminalApp::WindowRequestedArgs request{ windowId, std::move(args) };
-        request.WindowName(std::move(windowName));
-        CreateNewWindow(std::move(request));
-    }
+	if (window)
+	{
+		window->DispatchCommandline(std::move(args));
+	}
+	else
+	{
+		winrt::TerminalApp::WindowRequestedArgs request{ windowId, std::move(args) };
+		request.WindowName(std::move(windowName));
+		CreateNewWindow(std::move(request));
+	}
 }
 
 // This is an implementation-detail of _dispatchCommandline().
 safe_void_coroutine WindowEmperor::_dispatchCommandlineCurrentDesktop(winrt::TerminalApp::CommandlineArgs args)
 {
-    std::weak_ptr<AppHost> mostRecentWeak;
+	std::weak_ptr<AppHost> mostRecentWeak;
 
-    if (winrt::guid currentDesktop; VirtualDesktopUtils::GetCurrentVirtualDesktopId(reinterpret_cast<GUID*>(&currentDesktop)))
-    {
-        int64_t max = INT64_MIN;
-        for (const auto& w : _windows)
-        {
-            const auto lastActivatedTime = w->GetLastActivatedTime();
-            const auto desktopId = co_await w->GetVirtualDesktopId();
-            if (desktopId == currentDesktop && lastActivatedTime > max)
-            {
-                max = lastActivatedTime;
-                mostRecentWeak = w;
-            }
-        }
-    }
+	if (winrt::guid currentDesktop; VirtualDesktopUtils::GetCurrentVirtualDesktopId(reinterpret_cast<GUID*>(&currentDesktop)))
+	{
+		int64_t max = INT64_MIN;
+		for (const auto& w : _windows)
+		{
+			const auto lastActivatedTime = w->GetLastActivatedTime();
+			const auto desktopId = co_await w->GetVirtualDesktopId();
+			if (desktopId == currentDesktop && lastActivatedTime > max)
+			{
+				max = lastActivatedTime;
+				mostRecentWeak = w;
+			}
+		}
+	}
 
-    // GetVirtualDesktopId(), as current implemented, should always return on the main thread.
-    _assertIsMainThread();
+	// GetVirtualDesktopId(), as current implemented, should always return on the main thread.
+	_assertIsMainThread();
 
-    const auto mostRecent = mostRecentWeak.lock();
-    auto window = mostRecent.get();
+	const auto mostRecent = mostRecentWeak.lock();
+	auto window = mostRecent.get();
 
-    if (!window)
-    {
-        window = _mostRecentWindow();
-    }
+	if (!window)
+	{
+		window = _mostRecentWindow();
+	}
 
-    if (window)
-    {
-        window->DispatchCommandline(std::move(args));
-    }
-    else
-    {
-        CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs{ 0, std::move(args) });
-    }
+	if (window)
+	{
+		window->DispatchCommandline(std::move(args));
+	}
+	else
+	{
+		CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs{ 0, std::move(args) });
+	}
 }
 
 bool WindowEmperor::_summonWindow(const SummonWindowSelectionArgs& args) const
 {
-    AppHost* window = nullptr;
+	AppHost* window = nullptr;
 
-    if (args.WindowID)
-    {
-        for (const auto& w : _windows)
-        {
-            if (w->Logic().WindowProperties().WindowId() == args.WindowID)
-            {
-                window = w.get();
-                break;
-            }
-        }
-    }
-    else if (!args.WindowName.empty())
-    {
-        for (const auto& w : _windows)
-        {
-            if (w->Logic().WindowProperties().WindowName() == args.WindowName)
-            {
-                window = w.get();
-                break;
-            }
-        }
-    }
-    else
-    {
-        window = _mostRecentWindow();
-    }
+	if (args.WindowID)
+	{
+		for (const auto& w : _windows)
+		{
+			if (w->Logic().WindowProperties().WindowId() == args.WindowID)
+			{
+				window = w.get();
+				break;
+			}
+		}
+	}
+	else if (!args.WindowName.empty())
+	{
+		for (const auto& w : _windows)
+		{
+			if (w->Logic().WindowProperties().WindowName() == args.WindowName)
+			{
+				window = w.get();
+				break;
+			}
+		}
+	}
+	else
+	{
+		window = _mostRecentWindow();
+	}
 
-    if (!window)
-    {
-        return false;
-    }
+	if (!window)
+	{
+		return false;
+	}
 
-    window->HandleSummon(args.SummonBehavior);
-    return true;
+	window->HandleSummon(args.SummonBehavior);
+	return true;
 }
 
 void WindowEmperor::_summonAllWindows() const
 {
-    TerminalApp::SummonWindowBehavior args;
-    args.ToggleVisibility(false);
+	TerminalApp::SummonWindowBehavior args;
+	args.ToggleVisibility(false);
 
-    for (const auto& window : _windows)
-    {
-        window->HandleSummon(args);
-    }
+	for (const auto& window : _windows)
+	{
+		window->HandleSummon(args);
+	}
 }
 
 #pragma region WindowProc
 
 static WindowEmperor* GetThisFromHandle(HWND const window) noexcept
 {
-    const auto data = GetWindowLongPtrW(window, GWLP_USERDATA);
-    return reinterpret_cast<WindowEmperor*>(data);
+	const auto data = GetWindowLongPtrW(window, GWLP_USERDATA);
+	return reinterpret_cast<WindowEmperor*>(data);
 }
 
 [[nodiscard]] LRESULT __stdcall WindowEmperor::_wndProc(HWND const window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
 {
-    if (const auto that = GetThisFromHandle(window))
-    {
-        return that->_messageHandler(window, message, wparam, lparam);
-    }
+	if (const auto that = GetThisFromHandle(window))
+	{
+		return that->_messageHandler(window, message, wparam, lparam);
+	}
 
-    if (WM_NCCREATE == message)
-    {
-        const auto cs = reinterpret_cast<CREATESTRUCT*>(lparam);
-        const auto that = static_cast<WindowEmperor*>(cs->lpCreateParams);
-        that->_window.reset(window);
-        SetWindowLongPtrW(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(that));
-    }
+	if (WM_NCCREATE == message)
+	{
+		const auto cs = reinterpret_cast<CREATESTRUCT*>(lparam);
+		const auto that = static_cast<WindowEmperor*>(cs->lpCreateParams);
+		that->_window.reset(window);
+		SetWindowLongPtrW(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(that));
+	}
 
-    return DefWindowProcW(window, message, wparam, lparam);
+	return DefWindowProcW(window, message, wparam, lparam);
 }
 
 void WindowEmperor::_createMessageWindow(const wchar_t* className)
 {
-    const auto instance = reinterpret_cast<HINSTANCE>(&__ImageBase);
-    const auto icon = LoadIconW(instance, MAKEINTRESOURCEW(IDI_APPICON));
+	const auto instance = reinterpret_cast<HINSTANCE>(&__ImageBase);
+	const auto icon = LoadIconW(instance, MAKEINTRESOURCEW(IDI_APPICON));
 
-    const WNDCLASS wc{
-        .lpfnWndProc = &_wndProc,
-        .hInstance = instance,
-        .hIcon = icon,
-        .lpszClassName = className,
-    };
-    RegisterClassW(&wc);
+	const WNDCLASS wc{
+		.lpfnWndProc = &_wndProc,
+		.hInstance = instance,
+		.hIcon = icon,
+		.lpszClassName = className,
+	};
+	RegisterClassW(&wc);
 
-    WM_TASKBARCREATED = RegisterWindowMessageW(L"TaskbarCreated");
+	WM_TASKBARCREATED = RegisterWindowMessageW(L"TaskbarCreated");
 
-    // NOTE: This cannot be a HWND_MESSAGE window as otherwise we don't
-    // receive any HWND_BROADCAST messages, like WM_QUERYENDSESSION.
-    // NOTE: Before CreateWindowExW() returns it invokes our WM_NCCREATE
-    // message handler, which then stores the HWND in this->_window.
-    WINRT_VERIFY(CreateWindowExW(
-        /* dwExStyle    */ 0,
-        /* lpClassName  */ className,
-        /* lpWindowName */ L"Windows Terminal",
-        /* dwStyle      */ 0,
-        /* X            */ 0,
-        /* Y            */ 0,
-        /* nWidth       */ 0,
-        /* nHeight      */ 0,
-        /* hWndParent   */ nullptr,
-        /* hMenu        */ nullptr,
-        /* hInstance    */ instance,
-        /* lpParam      */ this));
+	// NOTE: This cannot be a HWND_MESSAGE window as otherwise we don't
+	// receive any HWND_BROADCAST messages, like WM_QUERYENDSESSION.
+	// NOTE: Before CreateWindowExW() returns it invokes our WM_NCCREATE
+	// message handler, which then stores the HWND in this->_window.
+	WINRT_VERIFY(CreateWindowExW(
+		/* dwExStyle    */ 0,
+		/* lpClassName  */ className,
+		/* lpWindowName */ L"Windows Terminal",
+		/* dwStyle      */ 0,
+		/* X            */ 0,
+		/* Y            */ 0,
+		/* nWidth       */ 0,
+		/* nHeight      */ 0,
+		/* hWndParent   */ nullptr,
+		/* hMenu        */ nullptr,
+		/* hInstance    */ instance,
+		/* lpParam      */ this));
 
-    _notificationIcon.cbSize = sizeof(NOTIFYICONDATA);
-    _notificationIcon.hWnd = _window.get();
-    _notificationIcon.uID = 1;
-    _notificationIcon.uFlags = NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP | NIF_ICON;
-    _notificationIcon.uCallbackMessage = WM_NOTIFY_FROM_NOTIFICATION_AREA;
-    _notificationIcon.hIcon = icon;
-    _notificationIcon.uVersion = NOTIFYICON_VERSION_4;
+	_notificationIcon.cbSize = sizeof(NOTIFYICONDATA);
+	_notificationIcon.hWnd = _window.get();
+	_notificationIcon.uID = 1;
+	_notificationIcon.uFlags = NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP | NIF_ICON;
+	_notificationIcon.uCallbackMessage = WM_NOTIFY_FROM_NOTIFICATION_AREA;
+	_notificationIcon.hIcon = icon;
+	_notificationIcon.uVersion = NOTIFYICON_VERSION_4;
 
-    // AppName happens to be in the ContextMenu's Resources, see GH#12264
-    const ScopedResourceLoader loader{ L"TerminalApp/ContextMenu" };
-    const auto appNameLoc = loader.GetLocalizedString(L"AppName");
-    StringCchCopy(_notificationIcon.szTip, ARRAYSIZE(_notificationIcon.szTip), appNameLoc.c_str());
+	// AppName happens to be in the ContextMenu's Resources, see GH#12264
+	const ScopedResourceLoader loader{ L"TerminalApp/ContextMenu" };
+	const auto appNameLoc = loader.GetLocalizedString(L"AppName");
+	StringCchCopy(_notificationIcon.szTip, ARRAYSIZE(_notificationIcon.szTip), appNameLoc.c_str());
 }
 
 // Posts a WM_QUIT as soon as we have no reason to exist anymore.
 // That basically means no windows and no message boxes.
 void WindowEmperor::_postQuitMessageIfNeeded() const
 {
-    if (
-        _messageBoxCount <= 0 &&
-        _windowCount <= 0 &&
-        !_app.Logic().Settings().GlobalSettings().AllowHeadless())
-    {
-        PostQuitMessage(0);
-    }
+	if (
+		_messageBoxCount <= 0 &&
+		_windowCount <= 0 &&
+		!_app.Logic().Settings().GlobalSettings().AllowHeadless())
+	{
+		PostQuitMessage(0);
+	}
 }
 
 safe_void_coroutine WindowEmperor::_showMessageBox(winrt::hstring message, bool error)
 {
-    // Prevent the main loop from exiting until the message box is closed.
-    // Once the loop exits, the app exits, and the message box will be closed.
-    _messageBoxCount += 1;
-    const auto decrement = wil::scope_exit([hwnd = _window.get()]() noexcept {
-        PostMessageW(hwnd, WM_MESSAGE_BOX_CLOSED, 0, 0);
-    });
+	// Prevent the main loop from exiting until the message box is closed.
+	// Once the loop exits, the app exits, and the message box will be closed.
+	_messageBoxCount += 1;
+	const auto decrement = wil::scope_exit([hwnd = _window.get()]() noexcept {
+		PostMessageW(hwnd, WM_MESSAGE_BOX_CLOSED, 0, 0);
+	});
 
-    // We must yield to a background thread, because MessageBoxW() is a blocking call, and we can't
-    // block the main thread. That would prevent us from servicing WM_COPYDATA messages and similar.
-    co_await winrt::resume_background();
+	// We must yield to a background thread, because MessageBoxW() is a blocking call, and we can't
+	// block the main thread. That would prevent us from servicing WM_COPYDATA messages and similar.
+	co_await winrt::resume_background();
 
-    const auto messageTitle = error ? IDS_ERROR_DIALOG_TITLE : IDS_HELP_DIALOG_TITLE;
-    const auto messageIcon = error ? MB_ICONERROR : MB_ICONWARNING;
-    // The dialog cannot have our _window as the parent, because that one is always hidden/invisible.
-    // TODO:GH#4134: polish this dialog more, to make the text more like msiexec /?
-    MessageBoxW(nullptr, message.c_str(), GetStringResource(messageTitle).c_str(), MB_OK | messageIcon);
+	const auto messageTitle = error ? IDS_ERROR_DIALOG_TITLE : IDS_HELP_DIALOG_TITLE;
+	const auto messageIcon = error ? MB_ICONERROR : MB_ICONWARNING;
+	// The dialog cannot have our _window as the parent, because that one is always hidden/invisible.
+	// TODO:GH#4134: polish this dialog more, to make the text more like msiexec /?
+	MessageBoxW(nullptr, message.c_str(), GetStringResource(messageTitle).c_str(), MB_OK | messageIcon);
 }
 
 LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM const wParam, LPARAM const lParam) noexcept
 {
-    try
-    {
-        switch (message)
-        {
-        case WM_CLOSE_TERMINAL_WINDOW:
-        {
-            const auto globalSettings = _app.Logic().Settings().GlobalSettings();
-            // Keep the last window in the array so that we can persist it on exit.
-            // We check for AllowHeadless(), as that being true prevents us from ever quitting in the first place.
-            // (= If we avoided closing the last window you wouldn't be able to reach a headless state.)
-            const auto shouldKeepWindow =
-                _windows.size() == 1 &&
-                globalSettings.ShouldUsePersistedLayout() &&
-                !globalSettings.AllowHeadless();
+	try
+	{
+		switch (message)
+		{
+		case WM_CLOSE_TERMINAL_WINDOW:
+		{
+			const auto globalSettings = _app.Logic().Settings().GlobalSettings();
+			// Keep the last window in the array so that we can persist it on exit.
+			// We check for AllowHeadless(), as that being true prevents us from ever quitting in the first place.
+			// (= If we avoided closing the last window you wouldn't be able to reach a headless state.)
+			const auto shouldKeepWindow =
+				_windows.size() == 1 &&
+				globalSettings.ShouldUsePersistedLayout() &&
+				!globalSettings.AllowHeadless();
 
-            if (!shouldKeepWindow)
-            {
-                // Did the window counter get out of sync? It shouldn't.
-                assert(_windowCount == gsl::narrow_cast<int32_t>(_windows.size()));
+			if (!shouldKeepWindow)
+			{
+				// Did the window counter get out of sync? It shouldn't.
+				assert(_windowCount == gsl::narrow_cast<int32_t>(_windows.size()));
 
-                const auto host = reinterpret_cast<AppHost*>(lParam);
-                auto it = _windows.begin();
-                const auto end = _windows.end();
+				const auto host = reinterpret_cast<AppHost*>(lParam);
+				auto it = _windows.begin();
+				const auto end = _windows.end();
 
-                for (; it != end; ++it)
-                {
-                    if (host == it->get())
-                    {
-                        host->Close();
-                        _windows.erase(it);
-                        break;
-                    }
-                }
-            }
+				for (; it != end; ++it)
+				{
+					if (host == it->get())
+					{
+						host->Close();
+						_windows.erase(it);
+						break;
+					}
+				}
+			}
 
-            // Counterpart specific to CreateNewWindow().
-            _windowCount -= 1;
-            _postQuitMessageIfNeeded();
-            return 0;
-        }
-        case WM_MESSAGE_BOX_CLOSED:
-            // Counterpart specific to _showMessageBox().
-            _messageBoxCount -= 1;
-            _postQuitMessageIfNeeded();
-            return 0;
-        case WM_IDENTIFY_ALL_WINDOWS:
-            for (const auto& host : _windows)
-            {
-                host->Logic().IdentifyWindow();
-            }
-            return 0;
-        case WM_NOTIFY_FROM_NOTIFICATION_AREA:
-            switch (LOWORD(lParam))
-            {
-            case NIN_SELECT:
-            case NIN_KEYSELECT:
-            {
-                SummonWindowSelectionArgs args;
-                args.SummonBehavior.MoveToCurrentDesktop(false);
-                args.SummonBehavior.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
-                args.SummonBehavior.ToggleVisibility(false);
-                std::ignore = _summonWindow(std::move(args));
-                break;
-            }
-            case WM_CONTEXTMENU:
-                _notificationAreaMenuRequested(wParam);
-                break;
-            default:
-                break;
-            }
-            return 0;
-        case WM_WINDOWPOSCHANGING:
-        {
-            // No, we really don't want this window to be visible. It hides the buggy CoreWindow that XAML creates.
-            // We can't make it a HWND_MESSAGE window, because then we don't get WM_QUERYENDSESSION messages.
-            const auto wp = reinterpret_cast<WINDOWPOS*>(lParam);
-            wp->flags &= ~SWP_SHOWWINDOW;
-            return 0;
-        }
-        case WM_MENUCOMMAND:
-            _notificationAreaMenuClicked(wParam, lParam);
-            return 0;
-        case WM_SETTINGCHANGE:
-            // Currently, we only support checking when the OS theme changes. In that case, wParam is 0.
-            // GH#15102: Re-evaluate when we decide to reload env vars.
-            //
-            // ImmersiveColorSet seems to be the notification that the OS theme
-            // changed. If that happens, let the app know, so it can hot-reload
-            // themes, color schemes that might depend on the OS theme
-            if (wParam == 0 && lParam != 0 && wcscmp(reinterpret_cast<const wchar_t*>(lParam), L"ImmersiveColorSet") == 0)
-            {
-                // GH#15732: Don't update the settings, unless the theme
-                // _actually_ changed. ImmersiveColorSet gets sent more often
-                // than just on a theme change. It notably gets sent when the PC
-                // is locked, or the UAC prompt opens.
-                const auto isCurrentlyDark = Theme::IsSystemInDarkTheme();
-                if (isCurrentlyDark != _currentSystemThemeIsDark)
-                {
-                    _currentSystemThemeIsDark = isCurrentlyDark;
-                    _app.Logic().ReloadSettings();
-                }
-            }
-            return 0;
-        case WM_COPYDATA:
-            if (const auto cds = reinterpret_cast<COPYDATASTRUCT*>(lParam); cds->dwData == TERMINAL_HANDOFF_MAGIC)
-            {
-                const auto handoff = deserializeHandoffPayload(static_cast<const uint8_t*>(cds->lpData), static_cast<const uint8_t*>(cds->lpData) + cds->cbData);
-                const winrt::hstring args{ handoff.args };
-                const winrt::hstring env{ handoff.env };
-                const winrt::hstring cwd{ handoff.cwd };
-                const auto argv = commandlineToArgArray(args.c_str());
-                _dispatchCommandline({ argv, cwd, gsl::narrow_cast<uint32_t>(handoff.show), env });
-            }
-            return 0;
-        case WM_HOTKEY:
-            _hotkeyPressed(static_cast<long>(wParam));
-            return 0;
-        case WM_QUERYENDSESSION:
-            // For WM_QUERYENDSESSION and WM_ENDSESSION, refer to:
-            // https://docs.microsoft.com/en-us/windows/win32/rstmgr/guidelines-for-applications
-            // ENDSESSION_CLOSEAPP: The application is using a file that must be replaced,
-            // the system is being serviced, or system resources are exhausted.
-            RegisterApplicationRestart(nullptr, RESTART_NO_CRASH | RESTART_NO_HANG);
-            return TRUE;
-        case WM_ENDSESSION:
-            _finalizeSessionPersistence();
-            _skipPersistence = true;
-            PostQuitMessage(0);
-            return 0;
-        default:
-            // We'll want to receive this message when explorer.exe restarts
-            // so that we can re-add our icon to the notification area.
-            // This unfortunately isn't a switch case because we register the
-            // message at runtime.
-            if (message == WM_TASKBARCREATED)
-            {
-                _notificationIconShown = false;
-                _checkWindowsForNotificationIcon();
-                return 0;
-            }
-        }
-    }
-    catch (...)
-    {
-        LOG_CAUGHT_EXCEPTION();
-    }
+			// Counterpart specific to CreateNewWindow().
+			_windowCount -= 1;
+			_postQuitMessageIfNeeded();
+			return 0;
+		}
+		case WM_MESSAGE_BOX_CLOSED:
+			// Counterpart specific to _showMessageBox().
+			_messageBoxCount -= 1;
+			_postQuitMessageIfNeeded();
+			return 0;
+		case WM_IDENTIFY_ALL_WINDOWS:
+			for (const auto& host : _windows)
+			{
+				host->Logic().IdentifyWindow();
+			}
+			return 0;
+		case WM_NOTIFY_FROM_NOTIFICATION_AREA:
+			switch (LOWORD(lParam))
+			{
+			case NIN_SELECT:
+			case NIN_KEYSELECT:
+			{
+				SummonWindowSelectionArgs args;
+				args.SummonBehavior.MoveToCurrentDesktop(false);
+				args.SummonBehavior.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
+				args.SummonBehavior.ToggleVisibility(false);
+				std::ignore = _summonWindow(std::move(args));
+				break;
+			}
+			case WM_CONTEXTMENU:
+				_notificationAreaMenuRequested(wParam);
+				break;
+			default:
+				break;
+			}
+			return 0;
+		case WM_WINDOWPOSCHANGING:
+		{
+			// No, we really don't want this window to be visible. It hides the buggy CoreWindow that XAML creates.
+			// We can't make it a HWND_MESSAGE window, because then we don't get WM_QUERYENDSESSION messages.
+			const auto wp = reinterpret_cast<WINDOWPOS*>(lParam);
+			wp->flags &= ~SWP_SHOWWINDOW;
+			return 0;
+		}
+		case WM_MENUCOMMAND:
+			_notificationAreaMenuClicked(wParam, lParam);
+			return 0;
+		case WM_SETTINGCHANGE:
+			// Currently, we only support checking when the OS theme changes. In that case, wParam is 0.
+			// GH#15102: Re-evaluate when we decide to reload env vars.
+			//
+			// ImmersiveColorSet seems to be the notification that the OS theme
+			// changed. If that happens, let the app know, so it can hot-reload
+			// themes, color schemes that might depend on the OS theme
+			if (wParam == 0 && lParam != 0 && wcscmp(reinterpret_cast<const wchar_t*>(lParam), L"ImmersiveColorSet") == 0)
+			{
+				// GH#15732: Don't update the settings, unless the theme
+				// _actually_ changed. ImmersiveColorSet gets sent more often
+				// than just on a theme change. It notably gets sent when the PC
+				// is locked, or the UAC prompt opens.
+				const auto isCurrentlyDark = Theme::IsSystemInDarkTheme();
+				if (isCurrentlyDark != _currentSystemThemeIsDark)
+				{
+					_currentSystemThemeIsDark = isCurrentlyDark;
+					_app.Logic().ReloadSettings();
+				}
+			}
+			return 0;
+		case WM_COPYDATA:
+			if (const auto cds = reinterpret_cast<COPYDATASTRUCT*>(lParam); cds->dwData == TERMINAL_HANDOFF_MAGIC)
+			{
+				const auto handoff = deserializeHandoffPayload(static_cast<const uint8_t*>(cds->lpData), static_cast<const uint8_t*>(cds->lpData) + cds->cbData);
+				const winrt::hstring args{ handoff.args };
+				const winrt::hstring env{ handoff.env };
+				const winrt::hstring cwd{ handoff.cwd };
+				const auto argv = commandlineToArgArray(args.c_str());
+				_dispatchCommandline({ argv, cwd, gsl::narrow_cast<uint32_t>(handoff.show), env });
+			}
+			return 0;
+		case WM_HOTKEY:
+			_hotkeyPressed(static_cast<long>(wParam));
+			return 0;
+		case WM_QUERYENDSESSION:
+			// For WM_QUERYENDSESSION and WM_ENDSESSION, refer to:
+			// https://docs.microsoft.com/en-us/windows/win32/rstmgr/guidelines-for-applications
+			// ENDSESSION_CLOSEAPP: The application is using a file that must be replaced,
+			// the system is being serviced, or system resources are exhausted.
+			RegisterApplicationRestart(nullptr, RESTART_NO_CRASH | RESTART_NO_HANG);
+			return TRUE;
+		case WM_ENDSESSION:
+			_finalizeSessionPersistence();
+			_skipPersistence = true;
+			PostQuitMessage(0);
+			return 0;
+		default:
+			// We'll want to receive this message when explorer.exe restarts
+			// so that we can re-add our icon to the notification area.
+			// This unfortunately isn't a switch case because we register the
+			// message at runtime.
+			if (message == WM_TASKBARCREATED)
+			{
+				_notificationIconShown = false;
+				_checkWindowsForNotificationIcon();
+				return 0;
+			}
+		}
+	}
+	catch (...)
+	{
+		LOG_CAUGHT_EXCEPTION();
+	}
 
-    return DefWindowProcW(window, message, wParam, lParam);
+	return DefWindowProcW(window, message, wParam, lParam);
 }
 
 void WindowEmperor::_setupSessionPersistence(bool enabled)
 {
-    if (!enabled)
-    {
-        _persistStateTimer.Stop();
-        return;
-    }
-    _persistStateTimer.Interval(std::chrono::minutes(5));
-    _persistStateTimer.Tick([&](auto&&, auto&&) {
-        _persistState(ApplicationState::SharedInstance(), false);
-    });
-    _persistStateTimer.Start();
+	if (!enabled)
+	{
+		_persistStateTimer.Stop();
+		return;
+	}
+	_persistStateTimer.Interval(std::chrono::minutes(5));
+	_persistStateTimer.Tick([&](auto&&, auto&&) {
+		_persistState(ApplicationState::SharedInstance(), false);
+	});
+	_persistStateTimer.Start();
 }
 
 void WindowEmperor::_persistState(const ApplicationState& state, bool serializeBuffer) const
 {
-    // Calling an `ApplicationState` setter triggers a write to state.json.
-    // With this if condition we avoid an unnecessary write when persistence is disabled.
-    if (state.PersistedWindowLayouts())
-    {
-        state.PersistedWindowLayouts(nullptr);
-    }
+	// Calling an `ApplicationState` setter triggers a write to state.json.
+	// With this if condition we avoid an unnecessary write when persistence is disabled.
+	if (state.PersistedWindowLayouts())
+	{
+		state.PersistedWindowLayouts(nullptr);
+	}
 
-    if (_app.Logic().Settings().GlobalSettings().ShouldUsePersistedLayout())
-    {
-        for (const auto& w : _windows)
-        {
-            w->Logic().PersistState(serializeBuffer);
-        }
-    }
+	if (_app.Logic().Settings().GlobalSettings().ShouldUsePersistedLayout())
+	{
+		for (const auto& w : _windows)
+		{
+			w->Logic().PersistState(serializeBuffer);
+		}
+	}
 
-    // Ensure to write the state.json
-    state.Flush();
+	// Ensure to write the state.json
+	state.Flush();
 }
 
 void WindowEmperor::_finalizeSessionPersistence() const
 {
-    if (_skipPersistence)
-    {
-        // We received WM_ENDSESSION and persisted the state.
-        // We don't need to persist it again.
-        return;
-    }
+	if (_skipPersistence)
+	{
+		// We received WM_ENDSESSION and persisted the state.
+		// We don't need to persist it again.
+		return;
+	}
 
-    const auto state = ApplicationState::SharedInstance();
+	const auto state = ApplicationState::SharedInstance();
 
-    _persistState(state, true);
+	_persistState(state, true);
 
-    if (_needsPersistenceCleanup)
-    {
-        // Get the "buffer_{guid}.txt" files that we expect to be there
-        std::unordered_set<winrt::guid> sessionIds;
-        if (const auto layouts = state.PersistedWindowLayouts())
-        {
-            for (const auto& windowLayout : layouts)
-            {
-                for (const auto& actionAndArgs : windowLayout.TabLayout())
-                {
-                    const auto args = actionAndArgs.Args();
-                    NewTerminalArgs terminalArgs{ nullptr };
+	if (_needsPersistenceCleanup)
+	{
+		// Get the "buffer_{guid}.txt" files that we expect to be there
+		std::unordered_set<winrt::guid> sessionIds;
+		if (const auto layouts = state.PersistedWindowLayouts())
+		{
+			for (const auto& windowLayout : layouts)
+			{
+				for (const auto& actionAndArgs : windowLayout.TabLayout())
+				{
+					const auto args = actionAndArgs.Args();
+					NewTerminalArgs terminalArgs{ nullptr };
 
-                    if (const auto tabArgs = args.try_as<NewTabArgs>())
-                    {
-                        terminalArgs = tabArgs.ContentArgs().try_as<NewTerminalArgs>();
-                    }
-                    else if (const auto paneArgs = args.try_as<SplitPaneArgs>())
-                    {
-                        terminalArgs = paneArgs.ContentArgs().try_as<NewTerminalArgs>();
-                    }
+					if (const auto tabArgs = args.try_as<NewTabArgs>())
+					{
+						terminalArgs = tabArgs.ContentArgs().try_as<NewTerminalArgs>();
+					}
+					else if (const auto paneArgs = args.try_as<SplitPaneArgs>())
+					{
+						terminalArgs = paneArgs.ContentArgs().try_as<NewTerminalArgs>();
+					}
 
-                    if (terminalArgs)
-                    {
-                        sessionIds.emplace(terminalArgs.SessionId());
-                    }
-                }
-            }
-        }
+					if (terminalArgs)
+					{
+						sessionIds.emplace(terminalArgs.SessionId());
+					}
+				}
+			}
+		}
 
-        // Remove the "buffer_{guid}.txt" files that shouldn't be there
-        // e.g. "buffer_FD40D746-163E-444C-B9B2-6A3EA2B26722.txt"
-        {
-            const std::filesystem::path settingsDirectory{ std::wstring_view{ CascadiaSettings::SettingsDirectory() } };
-            const auto filter = settingsDirectory / L"buffer_*";
-            WIN32_FIND_DATAW ffd;
+		// Remove the "buffer_{guid}.txt" files that shouldn't be there
+		// e.g. "buffer_FD40D746-163E-444C-B9B2-6A3EA2B26722.txt"
+		{
+			const std::filesystem::path settingsDirectory{ std::wstring_view{ CascadiaSettings::SettingsDirectory() } };
+			const auto filter = settingsDirectory / L"buffer_*";
+			WIN32_FIND_DATAW ffd;
 
-            // This could also use std::filesystem::directory_iterator.
-            // I was just slightly bothered by how it doesn't have a O(1) .filename()
-            // function, even though the underlying Win32 APIs provide it for free.
-            // Both work fine.
-            const wil::unique_hfind handle{ FindFirstFileExW(filter.c_str(), FindExInfoBasic, &ffd, FindExSearchNameMatch, nullptr, FIND_FIRST_EX_LARGE_FETCH) };
-            if (!handle)
-            {
-                return;
-            }
+			// This could also use std::filesystem::directory_iterator.
+			// I was just slightly bothered by how it doesn't have a O(1) .filename()
+			// function, even though the underlying Win32 APIs provide it for free.
+			// Both work fine.
+			const wil::unique_hfind handle{ FindFirstFileExW(filter.c_str(), FindExInfoBasic, &ffd, FindExSearchNameMatch, nullptr, FIND_FIRST_EX_LARGE_FETCH) };
+			if (!handle)
+			{
+				return;
+			}
 
-            do
-            {
-                const auto nameLen = wcsnlen_s(&ffd.cFileName[0], ARRAYSIZE(ffd.cFileName));
-                const std::wstring_view name{ &ffd.cFileName[0], nameLen };
+			do
+			{
+				const auto nameLen = wcsnlen_s(&ffd.cFileName[0], ARRAYSIZE(ffd.cFileName));
+				const std::wstring_view name{ &ffd.cFileName[0], nameLen };
 
-                if (nameLen != 47)
-                {
-                    continue;
-                }
+				if (nameLen != 47)
+				{
+					continue;
+				}
 
-                wchar_t guidStr[39];
-                guidStr[0] = L'{';
-                memcpy(&guidStr[1], name.data() + 7, 36 * sizeof(wchar_t));
-                guidStr[37] = L'}';
-                guidStr[38] = L'\0';
+				wchar_t guidStr[39];
+				guidStr[0] = L'{';
+				memcpy(&guidStr[1], name.data() + 7, 36 * sizeof(wchar_t));
+				guidStr[37] = L'}';
+				guidStr[38] = L'\0';
 
-                const auto id = Utils::GuidFromString(&guidStr[0]);
-                if (!sessionIds.contains(id))
-                {
-                    std::filesystem::remove(settingsDirectory / name);
-                }
-            } while (FindNextFileW(handle.get(), &ffd));
-        }
-    }
+				const auto id = Utils::GuidFromString(&guidStr[0]);
+				if (!sessionIds.contains(id))
+				{
+					std::filesystem::remove(settingsDirectory / name);
+				}
+			} while (FindNextFileW(handle.get(), &ffd));
+		}
+	}
 }
 
 void WindowEmperor::_notificationAreaMenuRequested(const WPARAM wParam)
 {
-    const auto menu = CreatePopupMenu();
-    if (!menu)
-    {
-        assert(false);
-        return;
-    }
+	const auto menu = CreatePopupMenu();
+	if (!menu)
+	{
+		assert(false);
+		return;
+	}
 
-    static constexpr MENUINFO mi{
-        .cbSize = sizeof(MENUINFO),
-        .fMask = MIM_STYLE | MIM_APPLYTOSUBMENUS | MIM_MENUDATA,
-        .dwStyle = MNS_NOTIFYBYPOS,
-    };
-    SetMenuInfo(menu, &mi);
+	static constexpr MENUINFO mi{
+		.cbSize = sizeof(MENUINFO),
+		.fMask = MIM_STYLE | MIM_APPLYTOSUBMENUS | MIM_MENUDATA,
+		.dwStyle = MNS_NOTIFYBYPOS,
+	};
+	SetMenuInfo(menu, &mi);
 
-    // The "Focus Terminal" menu item.
-    AppendMenuW(menu, MF_STRING, 0, RS_(L"NotificationIconFocusTerminal").c_str());
-    AppendMenuW(menu, MF_SEPARATOR, 0, L"");
+	// The "Focus Terminal" menu item.
+	AppendMenuW(menu, MF_STRING, 0, RS_(L"NotificationIconFocusTerminal").c_str());
+	AppendMenuW(menu, MF_SEPARATOR, 0, L"");
 
-    // A submenu to focus a specific window. Lists all windows that we manage.
-    if (const auto submenu = CreatePopupMenu())
-    {
-        static constexpr MENUINFO submenuInfo{
-            .cbSize = sizeof(MENUINFO),
-            .fMask = MIM_MENUDATA,
-            .dwStyle = MNS_NOTIFYBYPOS,
-        };
-        SetMenuInfo(submenu, &submenuInfo);
+	// A submenu to focus a specific window. Lists all windows that we manage.
+	if (const auto submenu = CreatePopupMenu())
+	{
+		static constexpr MENUINFO submenuInfo{
+			.cbSize = sizeof(MENUINFO),
+			.fMask = MIM_MENUDATA,
+			.dwStyle = MNS_NOTIFYBYPOS,
+		};
+		SetMenuInfo(submenu, &submenuInfo);
 
-        std::wstring displayText;
-        displayText.reserve(64);
+		std::wstring displayText;
+		displayText.reserve(64);
 
-        for (const auto& host : _windows)
-        {
-            const auto logic = host->Logic();
-            const auto props = logic.WindowProperties();
-            const auto id = props.WindowId();
+		for (const auto& host : _windows)
+		{
+			const auto logic = host->Logic();
+			const auto props = logic.WindowProperties();
+			const auto id = props.WindowId();
 
-            displayText.clear();
-            fmt::format_to(std::back_inserter(displayText), L"#{}", id);
-            if (const auto title = logic.Title(); !title.empty())
-            {
-                fmt::format_to(std::back_inserter(displayText), L": {}", title);
-            }
-            if (const auto name = props.WindowName(); !name.empty())
-            {
-                fmt::format_to(std::back_inserter(displayText), L" [{}]", name);
-            }
+			displayText.clear();
+			fmt::format_to(std::back_inserter(displayText), L"#{}", id);
+			if (const auto title = logic.Title(); !title.empty())
+			{
+				fmt::format_to(std::back_inserter(displayText), L": {}", title);
+			}
+			if (const auto name = props.WindowName(); !name.empty())
+			{
+				fmt::format_to(std::back_inserter(displayText), L" [{}]", name);
+			}
 
-            AppendMenuW(submenu, MF_STRING, gsl::narrow_cast<UINT_PTR>(id), displayText.c_str());
-        }
+			AppendMenuW(submenu, MF_STRING, gsl::narrow_cast<UINT_PTR>(id), displayText.c_str());
+		}
 
-        AppendMenuW(menu, MF_POPUP, reinterpret_cast<UINT_PTR>(submenu), RS_(L"NotificationIconWindowSubmenu").c_str());
-    }
+		AppendMenuW(menu, MF_POPUP, reinterpret_cast<UINT_PTR>(submenu), RS_(L"NotificationIconWindowSubmenu").c_str());
+	}
 
-    // We'll need to set our window to the foreground before calling
-    // TrackPopupMenuEx or else the menu won't dismiss when clicking away.
-    SetForegroundWindow(_window.get());
+	// We'll need to set our window to the foreground before calling
+	// TrackPopupMenuEx or else the menu won't dismiss when clicking away.
+	SetForegroundWindow(_window.get());
 
-    // User can select menu items with the left and right buttons.
-    const auto rightAlign = GetSystemMetrics(SM_MENUDROPALIGNMENT) != 0;
-    const UINT uFlags = TPM_RIGHTBUTTON | (rightAlign ? TPM_RIGHTALIGN : TPM_LEFTALIGN);
-    TrackPopupMenuEx(menu, uFlags, GET_X_LPARAM(wParam), GET_Y_LPARAM(wParam), _window.get(), nullptr);
+	// User can select menu items with the left and right buttons.
+	const auto rightAlign = GetSystemMetrics(SM_MENUDROPALIGNMENT) != 0;
+	const UINT uFlags = TPM_RIGHTBUTTON | (rightAlign ? TPM_RIGHTALIGN : TPM_LEFTALIGN);
+	TrackPopupMenuEx(menu, uFlags, GET_X_LPARAM(wParam), GET_Y_LPARAM(wParam), _window.get(), nullptr);
 
-    if (_currentWindowMenu)
-    {
-        // This will recursively destroy the submenu(s) as well.
-        DestroyMenu(_currentWindowMenu);
-    }
-    _currentWindowMenu = menu;
+	if (_currentWindowMenu)
+	{
+		// This will recursively destroy the submenu(s) as well.
+		DestroyMenu(_currentWindowMenu);
+	}
+	_currentWindowMenu = menu;
 }
 
 void WindowEmperor::_notificationAreaMenuClicked(const WPARAM wParam, const LPARAM lParam) const
 {
-    const auto menu = reinterpret_cast<HMENU>(lParam);
-    const auto menuItemIndex = LOWORD(wParam);
-    const auto windowId = GetMenuItemID(menu, menuItemIndex);
+	const auto menu = reinterpret_cast<HMENU>(lParam);
+	const auto menuItemIndex = LOWORD(wParam);
+	const auto windowId = GetMenuItemID(menu, menuItemIndex);
 
-    // _notificationAreaMenuRequested constructs each menu item with an ID
-    // that is either 0 for "Focus Terminal" or >0 for a specific window ID.
-    // This works well for us because valid window IDs are always >0.
-    SummonWindowSelectionArgs args;
-    args.WindowID = windowId;
-    args.SummonBehavior.ToggleVisibility(false);
-    args.SummonBehavior.MoveToCurrentDesktop(false);
-    args.SummonBehavior.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
-    std::ignore = _summonWindow(std::move(args));
+	// _notificationAreaMenuRequested constructs each menu item with an ID
+	// that is either 0 for "Focus Terminal" or >0 for a specific window ID.
+	// This works well for us because valid window IDs are always >0.
+	SummonWindowSelectionArgs args;
+	args.WindowID = windowId;
+	args.SummonBehavior.ToggleVisibility(false);
+	args.SummonBehavior.MoveToCurrentDesktop(false);
+	args.SummonBehavior.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
+	std::ignore = _summonWindow(std::move(args));
 }
 
 #pragma endregion
@@ -1172,68 +1179,68 @@ void WindowEmperor::_notificationAreaMenuClicked(const WPARAM wParam, const LPAR
 
 void WindowEmperor::_hotkeyPressed(const long hotkeyIndex)
 {
-    if (hotkeyIndex < 0 || static_cast<size_t>(hotkeyIndex) > _hotkeys.size())
-    {
-        return;
-    }
+	if (hotkeyIndex < 0 || static_cast<size_t>(hotkeyIndex) > _hotkeys.size())
+	{
+		return;
+	}
 
-    const auto& summonArgs = til::at(_hotkeys, hotkeyIndex);
+	const auto& summonArgs = til::at(_hotkeys, hotkeyIndex);
 
-    // desktop:any - MoveToCurrentDesktop=false, OnCurrentDesktop=false
-    // desktop:toCurrent - MoveToCurrentDesktop=true, OnCurrentDesktop=false
-    // desktop:onCurrent - MoveToCurrentDesktop=false, OnCurrentDesktop=true
-    SummonWindowSelectionArgs args;
-    args.WindowName = summonArgs.Name();
-    args.OnCurrentDesktop = summonArgs.Desktop() == DesktopBehavior::OnCurrent;
-    args.SummonBehavior.MoveToCurrentDesktop(summonArgs.Desktop() == DesktopBehavior::ToCurrent);
-    args.SummonBehavior.ToggleVisibility(summonArgs.ToggleVisibility());
-    args.SummonBehavior.DropdownDuration(summonArgs.DropdownDuration());
+	// desktop:any - MoveToCurrentDesktop=false, OnCurrentDesktop=false
+	// desktop:toCurrent - MoveToCurrentDesktop=true, OnCurrentDesktop=false
+	// desktop:onCurrent - MoveToCurrentDesktop=false, OnCurrentDesktop=true
+	SummonWindowSelectionArgs args;
+	args.WindowName = summonArgs.Name();
+	args.OnCurrentDesktop = summonArgs.Desktop() == DesktopBehavior::OnCurrent;
+	args.SummonBehavior.MoveToCurrentDesktop(summonArgs.Desktop() == DesktopBehavior::ToCurrent);
+	args.SummonBehavior.ToggleVisibility(summonArgs.ToggleVisibility());
+	args.SummonBehavior.DropdownDuration(summonArgs.DropdownDuration());
 
-    switch (summonArgs.Monitor())
-    {
-    case MonitorBehavior::Any:
-        args.SummonBehavior.ToMonitor(TerminalApp::MonitorBehavior::InPlace);
-        break;
-    case MonitorBehavior::ToCurrent:
-        args.SummonBehavior.ToMonitor(TerminalApp::MonitorBehavior::ToCurrent);
-        break;
-    case MonitorBehavior::ToMouse:
-        args.SummonBehavior.ToMonitor(TerminalApp::MonitorBehavior::ToMouse);
-        break;
-    }
+	switch (summonArgs.Monitor())
+	{
+	case MonitorBehavior::Any:
+		args.SummonBehavior.ToMonitor(TerminalApp::MonitorBehavior::InPlace);
+		break;
+	case MonitorBehavior::ToCurrent:
+		args.SummonBehavior.ToMonitor(TerminalApp::MonitorBehavior::ToCurrent);
+		break;
+	case MonitorBehavior::ToMouse:
+		args.SummonBehavior.ToMonitor(TerminalApp::MonitorBehavior::ToMouse);
+		break;
+	}
 
-    if (_summonWindow(args))
-    {
-        return;
-    }
+	if (_summonWindow(args))
+	{
+		return;
+	}
 
-    hstring argv[] = { L"wt", L"-w", summonArgs.Name() };
-    if (argv[2].empty())
-    {
-        argv[2] = L"new";
-    }
+	hstring argv[] = { L"wt", L"-w", summonArgs.Name() };
+	if (argv[2].empty())
+	{
+		argv[2] = L"new";
+	}
 
-    const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
-    const auto env = stringFromDoubleNullTerminated(envMem.get());
-    const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
-    _dispatchCommandline({ argv, cwd, SW_SHOWDEFAULT, std::move(env) });
+	const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
+	const auto env = stringFromDoubleNullTerminated(envMem.get());
+	const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
+	_dispatchCommandline({ argv, cwd, SW_SHOWDEFAULT, std::move(env) });
 }
 
 void WindowEmperor::_registerHotKey(const int index, const winrt::Microsoft::Terminal::Control::KeyChord& hotkey) noexcept
 {
-    const auto vkey = hotkey.Vkey();
-    auto hotkeyFlags = MOD_NOREPEAT;
-    {
-        const auto modifiers = hotkey.Modifiers();
-        WI_SetFlagIf(hotkeyFlags, MOD_WIN, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Windows));
-        WI_SetFlagIf(hotkeyFlags, MOD_ALT, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Menu));
-        WI_SetFlagIf(hotkeyFlags, MOD_CONTROL, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Control));
-        WI_SetFlagIf(hotkeyFlags, MOD_SHIFT, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Shift));
-    }
+	const auto vkey = hotkey.Vkey();
+	auto hotkeyFlags = MOD_NOREPEAT;
+	{
+		const auto modifiers = hotkey.Modifiers();
+		WI_SetFlagIf(hotkeyFlags, MOD_WIN, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Windows));
+		WI_SetFlagIf(hotkeyFlags, MOD_ALT, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Menu));
+		WI_SetFlagIf(hotkeyFlags, MOD_CONTROL, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Control));
+		WI_SetFlagIf(hotkeyFlags, MOD_SHIFT, WI_IsFlagSet(modifiers, VirtualKeyModifiers::Shift));
+	}
 
-    // TODO GH#8888: We should display a warning of some kind if this fails.
-    // This can fail if something else already bound this hotkey.
-    LOG_IF_WIN32_BOOL_FALSE(::RegisterHotKey(_window.get(), index, hotkeyFlags, vkey));
+	// TODO GH#8888: We should display a warning of some kind if this fails.
+	// This can fail if something else already bound this hotkey.
+	LOG_IF_WIN32_BOOL_FALSE(::RegisterHotKey(_window.get(), index, hotkeyFlags, vkey));
 }
 
 // Method Description:
@@ -1242,34 +1249,34 @@ void WindowEmperor::_registerHotKey(const int index, const winrt::Microsoft::Ter
 // - <none>
 void WindowEmperor::_unregisterHotKey(const int index) noexcept
 {
-    LOG_IF_WIN32_BOOL_FALSE(::UnregisterHotKey(_window.get(), index));
+	LOG_IF_WIN32_BOOL_FALSE(::UnregisterHotKey(_window.get(), index));
 }
 
 void WindowEmperor::_setupGlobalHotkeys()
 {
-    // Unregister all previously registered hotkeys.
-    //
-    // RegisterHotKey(), will not unregister hotkeys automatically.
-    // If a hotkey with a given HWND and ID combination already exists
-    // then a duplicate one will be added, which we don't want.
-    // (Additionally we want to remove hotkeys that were removed from the settings.)
-    for (auto i = 0, count = gsl::narrow_cast<int>(_hotkeys.size()); i < count; ++i)
-    {
-        _unregisterHotKey(i);
-    }
+	// Unregister all previously registered hotkeys.
+	//
+	// RegisterHotKey(), will not unregister hotkeys automatically.
+	// If a hotkey with a given HWND and ID combination already exists
+	// then a duplicate one will be added, which we don't want.
+	// (Additionally we want to remove hotkeys that were removed from the settings.)
+	for (auto i = 0, count = gsl::narrow_cast<int>(_hotkeys.size()); i < count; ++i)
+	{
+		_unregisterHotKey(i);
+	}
 
-    _hotkeys.clear();
+	_hotkeys.clear();
 
-    // Re-register all current hotkeys.
-    for (const auto& [keyChord, cmd] : _app.Logic().GlobalHotkeys())
-    {
-        if (auto summonArgs = cmd.ActionAndArgs().Args().try_as<Settings::Model::GlobalSummonArgs>())
-        {
-            const auto index = gsl::narrow_cast<int>(_hotkeys.size());
-            _registerHotKey(index, keyChord);
-            _hotkeys.emplace_back(summonArgs);
-        }
-    }
+	// Re-register all current hotkeys.
+	for (const auto& [keyChord, cmd] : _app.Logic().GlobalHotkeys())
+	{
+		if (auto summonArgs = cmd.ActionAndArgs().Args().try_as<Settings::Model::GlobalSummonArgs>())
+		{
+			const auto index = gsl::narrow_cast<int>(_hotkeys.size());
+			_registerHotKey(index, keyChord);
+			_hotkeys.emplace_back(summonArgs);
+		}
+	}
 }
 
 #pragma endregion
@@ -1278,54 +1285,54 @@ void WindowEmperor::_setupGlobalHotkeys()
 
 void WindowEmperor::_checkWindowsForNotificationIcon()
 {
-    // We need to check some conditions to show the notification icon.
-    //
-    // * If there's a Quake window somewhere, we'll want to keep the
-    //   notification icon.
-    // * There's two settings - MinimizeToNotificationArea and
-    //   AlwaysShowNotificationIcon. If either one of them are true, we want to
-    //   make sure there's a notification icon.
-    //
-    // If both are false, we want to remove our icon from the notification area.
-    // When we remove our icon from the notification area, we'll also want to
-    // re-summon any hidden windows, but right now we're not keeping track of
-    // who's hidden, so just summon them all. Tracking the work to do a "summon
-    // all minimized" in GH#10448
-    //
-    // To avoid races between us thinking the settings updated, and the windows
-    // themselves getting the new settings, only ask the app logic for the
-    // RequestsTrayIcon setting value, and combine that with the result of each
-    // window (which won't change during a settings reload).
-    const auto globals = _app.Logic().Settings().GlobalSettings();
-    auto needsIcon = globals.AlwaysShowNotificationIcon() || globals.MinimizeToNotificationArea();
-    if (!needsIcon)
-    {
-        for (const auto& host : _windows)
-        {
-            needsIcon |= host->Logic().IsQuakeWindow();
-        }
-    }
+	// We need to check some conditions to show the notification icon.
+	//
+	// * If there's a Quake window somewhere, we'll want to keep the
+	//   notification icon.
+	// * There's two settings - MinimizeToNotificationArea and
+	//   AlwaysShowNotificationIcon. If either one of them are true, we want to
+	//   make sure there's a notification icon.
+	//
+	// If both are false, we want to remove our icon from the notification area.
+	// When we remove our icon from the notification area, we'll also want to
+	// re-summon any hidden windows, but right now we're not keeping track of
+	// who's hidden, so just summon them all. Tracking the work to do a "summon
+	// all minimized" in GH#10448
+	//
+	// To avoid races between us thinking the settings updated, and the windows
+	// themselves getting the new settings, only ask the app logic for the
+	// RequestsTrayIcon setting value, and combine that with the result of each
+	// window (which won't change during a settings reload).
+	const auto globals = _app.Logic().Settings().GlobalSettings();
+	auto needsIcon = globals.AlwaysShowNotificationIcon() || globals.MinimizeToNotificationArea();
+	if (!needsIcon)
+	{
+		for (const auto& host : _windows)
+		{
+			needsIcon |= host->Logic().IsQuakeWindow();
+		}
+	}
 
-    if (_notificationIconShown == needsIcon)
-    {
-        return;
-    }
+	if (_notificationIconShown == needsIcon)
+	{
+		return;
+	}
 
-    if (needsIcon)
-    {
-        Shell_NotifyIconW(NIM_ADD, &_notificationIcon);
-        Shell_NotifyIconW(NIM_SETVERSION, &_notificationIcon);
-    }
-    else
-    {
-        Shell_NotifyIconW(NIM_DELETE, &_notificationIcon);
-        // If we no longer want the tray icon, but we did have one, then quick
-        // re-summon all our windows, so they don't get lost when the icon
-        // disappears forever.
-        _summonAllWindows();
-    }
+	if (needsIcon)
+	{
+		Shell_NotifyIconW(NIM_ADD, &_notificationIcon);
+		Shell_NotifyIconW(NIM_SETVERSION, &_notificationIcon);
+	}
+	else
+	{
+		Shell_NotifyIconW(NIM_DELETE, &_notificationIcon);
+		// If we no longer want the tray icon, but we did have one, then quick
+		// re-summon all our windows, so they don't get lost when the icon
+		// disappears forever.
+		_summonAllWindows();
+	}
 
-    _notificationIconShown = needsIcon;
+	_notificationIconShown = needsIcon;
 }
 
 #pragma endregion


### PR DESCRIPTION
## Summary by Sourcery

Add project name support throughout Terminal configuration and remoting, allowing users to specify a project context via a new CLI option and environment variable, and segregate settings storage accordingly. Also expose project name in remoting APIs and adjust settings file resolution to include a “Projects\<projectName>” directory.

New Features:
- Introduce a --project CLI flag to specify a project name for Terminal sessions
- Set and propagate a new WT_PROJECT_NAME environment variable based on the project CLI argument
- Include an optional Projects\<projectName> subfolder when resolving base and release settings paths
- Expose ProjectName in CommandlineArgs and remoting APIs for inter-process handoff and scripting

Enhancements:
- Normalize indentation and formatting across multiple source files
- Update build script to reference the project-specific certificate path

Chores:
- Clean up whitespace and align style in functions and class methods